### PR TITLE
fix(useExpanded) (useRowSelect): Memoize some variables

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -396,6 +396,12 @@ export const useTable = (props, ...plugins) => {
 
   getInstance().prepareRow = React.useCallback(
     row => {
+      if (row.preparedWith === getInstance().state) {
+        return
+      }
+
+      row.preparedWith = getInstance().state
+      
       row.getRowProps = makePropGetter(getHooks().getRowProps, {
         instance: getInstance(),
         row,

--- a/src/plugin-hooks/useExpanded.js
+++ b/src/plugin-hooks/useExpanded.js
@@ -142,15 +142,17 @@ function useInstance(instance) {
 
   const getAutoResetExpanded = useGetLatest(autoResetExpanded)
 
-  let isAllRowsExpanded = Boolean(
-    Object.keys(rowsById).length && Object.keys(expanded).length
-  )
+  let isAllRowsExpanded = React.useMemo(() => {
+    let flag = Boolean(
+      Object.keys(rowsById).length && Object.keys(expanded).length
+    )
 
-  if (isAllRowsExpanded) {
-    if (Object.keys(rowsById).some(id => !expanded[id])) {
-      isAllRowsExpanded = false
+    if (flag && Object.keys(rowsById).some(id => !expanded[id])) {
+      flag = false
     }
-  }
+
+    return flag
+  }, [expanded, rowsById])
 
   // Bypass any effects from firing when this changes
   useMountedLayoutEffect(() => {

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -256,9 +256,12 @@ function useInstance(instance) {
     return selectedFlatRows
   }, [rows, selectSubRows, selectedRowIds, getSubRows])
 
-  let isAllRowsSelected = Boolean(
-    Object.keys(nonGroupedRowsById).length && Object.keys(selectedRowIds).length
-  )
+  let isAllRowsSelected = React.useMemo(() => {
+    return Boolean(
+      Object.keys(nonGroupedRowsById).length &&
+        Object.keys(selectedRowIds).length
+    )
+  }, [nonGroupedRowsById, selectedRowIds])
 
   let isAllPageRowsSelected = isAllRowsSelected
 


### PR DESCRIPTION
Avoid expensive calculation of `isAllRowsExpanded` on re-renders