### PR TITLE
Fix: Column header should have the same flex value as column data

### DIFF
--- a/src/plugin-hooks/useFlexLayout.js
+++ b/src/plugin-hooks/useFlexLayout.js
@@ -35,9 +35,7 @@ const getHeaderProps = (props, { column }) => [
   {
     style: {
       boxSizing: 'border-box',
-      flex: column.totalFlexWidth
-        ? `${column.totalFlexWidth} 0 auto`
-        : undefined,
+      flex: `${column.totalFlexWidth} 0 auto`,
       minWidth: `${column.totalMinWidth}px`,
       width: `${column.totalWidth}px`,
     },


### PR DESCRIPTION
## Current Behavior
WHEN using FlexLayout
AND using a non-resizable column where width should be determined by size of content (for example checkboxes)
AND the window is resized to be smaller than the minwidth of the table
THEN the header cell does not maintain it's space, but the data cells do, which causes the header to not line up with the data anymore
Example: https://codesandbox.io/s/gallant-haslett-twq7l?file=/src/App.js

## Expected Behavior
The header cell should behave consistently with the data cells on resize.

## Findings
There is a special case for flex, where it is not being set if `totalFlexWidth` is falsey.  This value is set to 0 when the `canResize` property is false.
```javascript
header.totalFlexWidth = header.canResize ? header.totalWidth : 0
``` 
Since 0 is falsey, instead of setting `flex: 0 0 auto`, it doesn't set flex at all.  This case is not present on the table data properties.  0 0 auto is exactly what we are looking for, saying that it should not grow, or expand, and it's size is determined by the element's size. 
It looks like it was introduced in this PR, but I have not be able to determine what it was included to fix. 
https://github.com/tannerlinsley/react-table/pull/1924

It's very possible I've misunderstood, or misconfigured something here, so please let me know if that's the case as well.
