### PR TITLE
fix(useFilters): fix and improve useFilters #2928

### DIFF
--- a/docs/src/pages/docs/api/useFilters.md
+++ b/docs/src/pages/docs/api/useFilters.md
@@ -74,6 +74,11 @@ The following values are provided to the table `instance`:
   - An instance-level function used to update the values for **all** filters on the table, all at once.
   - `filtersObjectArray` is an array of objects with `id` and `value` keys. Example: `[{ id: 'columnAccessor', value: 'valueToFilter' }]`
   - **Note:** You must call `setAllFilters` with an array, even if that array is empty. Example: `setAllFilters([])`
+- `filteredFlatRows: Array<Row>`
+  - An array of all Rows including subRows which have been matched by the filter and have been flattened into the order in which they were detected (depth first)
+  - This can be helpful in calculating total row counts that must include subRow
+- `filteredRowsById: Object<rowId: Row>`
+  - An object of all Rows including subRows which have been matched by the filter.
 
 ### Column Properties
 
@@ -91,6 +96,20 @@ The following properties are available on every `Column` object returned by the 
 - `filteredRows: Array<row>`
   - The resulting array of rows received from this column's filter **after** filtering took place.
   - This array of rows can be useful if building faceted filter options.
+
+### Row Properties
+
+The following properties are available on every `Row` Object returned from the table instance
+
+- `subRows: Array<Row>`
+  - An array of **filtered** subRows.
+- `preFilteredSubRows: Array<Row>`
+  - An array of subRows **used right before filtering**.
+- `filteredFlatRows: Array<Row>`
+  - An array of all subRows, including sub-subRows, which have been matched by the filter and have been flattened into the order in which they were detected (depth first)
+  - This can be helpful in calculating total subRow counts and if some descendant row has been matched while the current row is not
+- `filteredRowsById: Object<rowId: Row>`
+  - An object of all subRows, including sub-subRows which, have been matched by the filter.
 
 ### Example
 

--- a/src/publicUtils.js
+++ b/src/publicUtils.js
@@ -6,8 +6,8 @@ export const actions = {
   init: 'init',
 }
 
-export const defaultRenderer = ({ value = '' }) => value;
-export const emptyRenderer = () => <>&nbsp;</>;
+export const defaultRenderer = ({ value = '' }) => value
+export const emptyRenderer = () => <>&nbsp;</>
 
 export const defaultColumn = {
   Cell: defaultRenderer,
@@ -237,4 +237,9 @@ function isExoticComponent(component) {
     typeof component.$$typeof === 'symbol' &&
     ['react.memo', 'react.forward_ref'].includes(component.$$typeof.description)
   )
+}
+
+//pass data through each mapper one at a time in order
+export function reduceMappings(data, mappings) {
+  return mappings.reduce((data, mapping) => mapping(data), data)
 }


### PR DESCRIPTION
This fixed the problem outlined in #2928 and adds filter related row properties. (see docs changes)

Previously when filtering nested data, if the parent row didn't match a filter then the children would be removed *even if they matched the filter*

By using this updated useFilters and useExpanded you can filter for descendants who's parent's don't match the filter

https://user-images.githubusercontent.com/16736623/102681167-42181200-418d-11eb-9058-e0f433bf1ce4.mp4

