### PR TITLE
fix(useRowSelect): fix getToggleAllRowsSelectedProps logic

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -68,7 +68,7 @@ const defaultGetToggleAllRowsSelectedProps = (props, { instance }) => [
     title: 'Toggle All Rows Selected',
     indeterminate: Boolean(
       !instance.isAllRowsSelected &&
-        Object.keys(instance.state.selectedRowIds).length
+        instance.initialRows.some(({ id }) => instance.state.selectedRowIds[id])
     ),
   },
 ]


### PR DESCRIPTION
- only return true when at least one of the selectedRows is present in data

Steps to reproduce the bug:
1. Create a table with row selection and autoResetSelectedRows: false and getRowId uniquely identifying the row.
2. Select a row and delete it.
3. intermediate is still true even though none of the rows in data is selected.

This is useful when implementing a row select and delete. When I click undo delete, I want the rows to still be selected. This helps with that.