### PR TITLE
fix(useGridLayout): handle column.width & hidden columns

### DIFF
--- a/src/plugin-hooks/tests/useGridLayout.test.js
+++ b/src/plugin-hooks/tests/useGridLayout.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useTable } from '../../hooks/useTable'
 import { useGridLayout } from '../useGridLayout'
-import { render } from '../../../test-utils/react-testing'
+import { render, fireEvent } from '../../../test-utils/react-testing'
 
 const data = [
   {
@@ -36,33 +36,45 @@ function Table({ columns, data }) {
     headerGroups,
     rows,
     prepareRow,
+    toggleHideColumn,
   } = useTable(
     {
       columns,
       data,
     },
-    useGridLayout,
+    useGridLayout
   )
 
+  const testHiddenColumn = () => {
+    toggleHideColumn('visits')
+  }
+
   return (
-    <div {...getTableProps()} className="table">
-      {headerGroups.map(headerGroup => (
-        headerGroup.headers.map(column => (
-          <div key={column.id} {...column.getHeaderProps()} className="cell header">
-            {column.render('Header')}
-          </div>
-        ))
-      ))}
-      {rows.map(row => 
-        prepareRow(row) || (
-          row.cells.map(cell => (
-            <div {...cell.getCellProps()} className="cell">
-              {cell.render('Cell')}
+    <>
+      <button onClick={() => testHiddenColumn({})}>Hide Test Column</button>
+      <div {...getTableProps()} className="table">
+        {headerGroups.map(headerGroup =>
+          headerGroup.headers.map(column => (
+            <div
+              key={column.id}
+              {...column.getHeaderProps()}
+              className="cell header"
+            >
+              {column.render('Header')}
             </div>
           ))
-        )
-      )}
-    </div>
+        )}
+        {rows.map(
+          row =>
+            prepareRow(row) ||
+            row.cells.map(cell => (
+              <div {...cell.getCellProps()} className="cell">
+                {cell.render('Cell')}
+              </div>
+            ))
+        )}
+      </div>
+    </>
   )
 }
 
@@ -80,6 +92,7 @@ function App() {
       {
         Header: 'Age',
         accessor: 'age',
+        width: '4rem',
       },
       {
         Header: 'Visits',
@@ -101,11 +114,25 @@ function App() {
 }
 
 test('renders a table', () => {
-  const rendered = render(<App />)
+  render(<App />)
+})
 
+test('respects column.width', () => {
+  const rendered = render(<App />)
   const [table] = rendered.queryAllByRole('table')
 
   expect(table.getAttribute('style')).toEqual(
-    'display: grid; grid-template-columns: auto auto auto auto auto auto;'
+    'display: grid; grid-template-columns: auto auto 4rem auto auto auto;'
+  )
+})
+
+test('respects hidden columns', () => {
+  const rendered = render(<App />)
+  const [table] = rendered.queryAllByRole('table')
+
+  fireEvent.click(rendered.getByText('Hide Test Column'))
+
+  expect(table.getAttribute('style')).toEqual(
+    'display: grid; grid-template-columns: auto auto 4rem auto auto;'
   )
 })

--- a/src/plugin-hooks/useGridLayout.js
+++ b/src/plugin-hooks/useGridLayout.js
@@ -6,22 +6,32 @@ export function useGridLayout(hooks) {
 
 useGridLayout.pluginName = 'useGridLayout'
 
-const getTableProps = (props, { instance }) => [
-  props,
-  {
-    style: {
-      display: `grid`,
-      gridTemplateColumns: instance.state.gridLayout.columnWidths.map(w => w).join(` `),
+const getTableProps = (props, { instance }) => {
+  const columnWidths = instance.visibleColumns.map(column => {
+    const index = instance.allColumns.findIndex(col => col.id === column.id)
+    const width = instance.state.gridLayout.columnWidths[index]
+    if (column.width !== 150 && width === `auto`) {
+      return column.width || `auto`
+    }
+    return width
+  })
+  return [
+    props,
+    {
+      style: {
+        display: `grid`,
+        gridTemplateColumns: columnWidths.join(` `),
+      },
     },
-  },
-]
+  ]
+}
 
 const getHeaderProps = (props, { column }) => [
   props,
   {
     id: `header-cell-${column.id}`,
     style: {
-      position: `sticky` //enables a scroll wrapper to be placed around the table and have sticky headers
+      position: `sticky`, //enables a scroll wrapper to be placed around the table and have sticky headers
     },
   },
 ]
@@ -38,7 +48,9 @@ function reducer(state, action, previousState, instance) {
 
   if (action.type === `columnStartResizing`) {
     const { columnId } = action
-    const columnIndex = instance.visibleColumns.findIndex(col => col.id === columnId)
+    const columnIndex = instance.visibleColumns.findIndex(
+      col => col.id === columnId
+    )
     const elWidth = getElementWidth(columnId)
 
     if (elWidth !== undefined) {
@@ -48,7 +60,7 @@ function reducer(state, action, previousState, instance) {
           ...state.gridLayout,
           columnId,
           columnIndex,
-          startingWidth: elWidth
+          startingWidth: elWidth,
         },
       }
     } else {
@@ -57,11 +69,7 @@ function reducer(state, action, previousState, instance) {
   }
 
   if (action.type === `columnResizing`) {
-    const {
-      columnIndex,
-      startingWidth,
-      columnWidths,
-    } = state.gridLayout
+    const { columnIndex, startingWidth, columnWidths } = state.gridLayout
 
     const change = state.columnResizing.startX - action.clientX
     const newWidth = startingWidth - change


### PR DESCRIPTION
Steps to reproduce the bug:
1. Create a table with useGridLayout & add width attribute to at least one of the columns
2. => width attribute is not respected
3. Hide a column => The table is all messed up because it is still rendered with the default number of columns

CSS grids provide awesome ways of managing widths, being able to use that with react-table would be awesome.