### PR TITLE
fix(useGridLayout): handle expanded rows

### DIFF
--- a/src/plugin-hooks/useGridLayout.js
+++ b/src/plugin-hooks/useGridLayout.js
@@ -2,6 +2,7 @@ export function useGridLayout(hooks) {
   hooks.stateReducers.push(reducer)
   hooks.getTableProps.push(getTableProps)
   hooks.getHeaderProps.push(getHeaderProps)
+  hooks.getRowProps.push(getRowProps)
 }
 
 useGridLayout.pluginName = 'useGridLayout'
@@ -76,6 +77,20 @@ function reducer(state, action, previousState, instance) {
       },
     }
   }
+}
+
+const getRowProps = (props, { row }) => {
+  if (row.isExpanded) {
+    return [
+      props,
+      {
+        style: {
+          gridColumn: `1 / ${row.cells.length + 1}`,
+        },
+      },
+    ]
+  }
+  return [props, {}]
 }
 
 function getElementWidth(columnId) {


### PR DESCRIPTION
Steps to reproduce:
1. Create a table with useGridLayout & rows with subcomponents
2. Expand a row => The table is all messed up because the subcomponent is considered as a cell.

We don't/can't use getRowProps with useGridLayout, because cells are rendered directly onto the CSS grid, so we can instead use this function on expanded rows to correctly add the grid-column props to it.