### PR TITLE
feat(useSortBy): provide parent row to orderBy function

### DIFF
--- a/docs/src/components/CarbonAds.js
+++ b/docs/src/components/CarbonAds.js
@@ -1,0 +1,45 @@
+import React from 'react'
+
+function buildScript(src, attrs = {}) {
+  if (typeof document !== 'undefined') {
+    const script = document.createElement('script')
+    script.async = true
+    script.defer = true
+    Object.keys(attrs).forEach(attr => script.setAttribute(attr, attrs[attr]))
+    script.src = src
+
+    return script
+  }
+}
+
+export default function CarbonAds() {
+  const ref = React.useRef()
+
+  React.useEffect(() => {
+    const script = buildScript(
+      '//cdn.carbonads.com/carbon.js?serve=CESDV2QJ&placement=react-tabletanstackcom',
+      {
+        type: 'text/javascript',
+        id: '_carbonads_js',
+      }
+    )
+
+    ref.current.appendChild(script)
+  }, [])
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      ;[...ref.current.children].forEach(child => {
+        if (child.id.startsWith('carbonads_')) {
+          ref.current.removeChild(child)
+        }
+      })
+    }, 100)
+
+    return () => {
+      clearInterval(interval)
+    }
+  })
+
+  return <div ref={ref} />
+}

--- a/docs/src/components/Footer.js
+++ b/docs/src/components/Footer.js
@@ -1,93 +1,94 @@
 import * as React from 'react'
 import Link from 'next/link'
+import CarbonAds from './CarbonAds'
+
 export const Footer = props => {
   return (
     <div className="bg-gray-50 border-t border-gray-200">
       <div className="container mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8">
-        <div className="xl:grid xl:grid-cols-3 xl:gap-8">
-          <div className="grid grid-cols-2 gap-8 xl:col-span-2">
-            <div className="md:grid md:grid-cols-2 md:gap-8">
-              <div>
-                <h4 className="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
-                  Resources
-                </h4>
-                <ul className="mt-4">
-                  <li>
-                    <Link href="/docs/overview">
-                      <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
-                        Docs
-                      </a>
-                    </Link>
-                  </li>
-                  <li className="mt-4">
-                    <Link href="/docs/examples/basic">
-                      <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
-                        Examples
-                      </a>
-                    </Link>
-                  </li>
-                  <li className="mt-4">
-                    <Link href="/docs/api/overview">
-                      <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
-                        API Reference
-                      </a>
-                    </Link>
-                  </li>
-                </ul>
-              </div>
-              <div className="mt-12 md:mt-0">
-                <h4 className="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
-                  Community
-                </h4>
-                <ul className="mt-4">
-                  <li className="mt-4">
-                    <a
-                      href="https://github.com/tannerlinsley/react-table/discussions"
-                      className="text-base leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                      Forum & Support
-                    </a>
-                  </li>
-                  <li className="mt-4">
-                    <a
-                      href="https://discord.gg/WrRKjPJ"
-                      className="text-base leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                      #TanStack Discord
-                    </a>
-                  </li>
-                  <li className="mt-4">
-                    <a
-                      href="http://stackoverflow.com/questions/tagged/react-table"
-                      className="text-base leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                      Stack Overflow
-                    </a>
-                  </li>
-                  <li className="mt-4">
-                    <a
-                      href="https://github.com/tannerlinsley/react-table/releases"
-                      className="text-base leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                      Releases
-                    </a>
-                  </li>
-                  <li className="mt-4">
-                    <a
-                      className="github-button"
-                      href="https://github.com/tannerlinsley/react-table"
-                      data-color-scheme="no-preference: light; light: light; dark: dark;"
-                      data-icon="octicon-star"
-                      data-size="large"
-                      data-show-count="true"
-                      aria-label="Star tannerlinsley/react-table on GitHub"
-                    >
-                      Star
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
+        <div className="grid-cols-2 md:grid xl:grid-cols-4 md:gap-8">
+          <div>
+            <h4 className="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+              Resources
+            </h4>
+            <ul className="mt-4">
+              <li>
+                <Link href="/docs/overview">
+                  <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
+                    Docs
+                  </a>
+                </Link>
+              </li>
+              <li className="mt-4">
+                <Link href="/docs/examples/basic">
+                  <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
+                    Examples
+                  </a>
+                </Link>
+              </li>
+              <li className="mt-4">
+                <Link href="/docs/api/overview">
+                  <a className="text-base leading-6 text-gray-500 hover:text-gray-900">
+                    API Reference
+                  </a>
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div className="mt-12 md:mt-0">
+            <h4 className="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">
+              Community
+            </h4>
+            <ul className="mt-4">
+              <li className="mt-4">
+                <a
+                  href="https://github.com/tannerlinsley/react-table/discussions"
+                  className="text-base leading-6 text-gray-500 hover:text-gray-900"
+                >
+                  Forum & Support
+                </a>
+              </li>
+              <li className="mt-4">
+                <a
+                  href="https://discord.gg/WrRKjPJ"
+                  className="text-base leading-6 text-gray-500 hover:text-gray-900"
+                >
+                  #TanStack Discord
+                </a>
+              </li>
+              <li className="mt-4">
+                <a
+                  href="http://stackoverflow.com/questions/tagged/react-table"
+                  className="text-base leading-6 text-gray-500 hover:text-gray-900"
+                >
+                  Stack Overflow
+                </a>
+              </li>
+              <li className="mt-4">
+                <a
+                  href="https://github.com/tannerlinsley/react-table/releases"
+                  className="text-base leading-6 text-gray-500 hover:text-gray-900"
+                >
+                  Releases
+                </a>
+              </li>
+              <li className="mt-4">
+                <a
+                  className="github-button"
+                  href="https://github.com/tannerlinsley/react-table"
+                  data-color-scheme="no-preference: light; light: light; dark: dark;"
+                  data-icon="octicon-star"
+                  data-size="large"
+                  data-show-count="true"
+                  aria-label="Star tannerlinsley/react-table on GitHub"
+                >
+                  Star
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div className="mt-8 xl:mt-0">
+            <CarbonAds />
           </div>
           <div className="mt-8 xl:mt-0">
             <h4 className="text-sm leading-5 font-semibold tracking-wider text-gray-400 uppercase">

--- a/docs/src/components/Sidebar.js
+++ b/docs/src/components/Sidebar.js
@@ -1,13 +1,15 @@
 import { useState } from 'react'
 import cn from 'classnames'
 import { Search } from './Search'
+import CarbonAds from './CarbonAds'
+
 export const Sidebar = ({ active, children, fixed }) => {
   const [searching, setSearching] = useState(false)
   return (
     <aside
       className={cn('sidebar bg-white top-24 flex-shrink-0 pr-2', {
         active,
-        ['pb-0 flex flex-col z-1 sticky']: fixed,
+        'pb-0 flex flex-col z-1 sticky': fixed,
         fixed,
         searching,
       })}
@@ -16,9 +18,12 @@ export const Sidebar = ({ active, children, fixed }) => {
         <Search />
       </div>
       <div className="sidebar-content overflow-y-auto pb-4">{children}</div>
+      <CarbonAds />
       <style jsx>{`
         .sidebar {
           -webkit-overflow-scrolling: touch;
+          display: flex;
+          flex-direction: column;
         }
         .sidebar.fixed {
           width: 300px;

--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -36,7 +36,7 @@ The following options are supported via the main options object passed to `useTa
   - If true, the un-sorted state will not be available to columns once they have been sorted.
 - `disableMultiRemove: Bool`
   - If true, the un-sorted state will not be available to multi-sorted columns.
-- `orderByFn: Function`
+- `orderByFn: Function( data, sortFunctions, directions, parentRow )`
   - Must be **memoized**
   - Defaults to the built-in default orderBy function
   - This function is responsible for composing multiple sorting functions together for multi-sorting, and also handles both the directional sorting and stable-sorting tie breaking. Rarely would you want to override this function unless you have a very advanced use-case that requires it.

--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -75,7 +75,7 @@ The following options are supported on any `Column` object passed to the `column
 - `sortType: String | Function(rowA: <Row>, rowB: <Row>, columnId: String, desc: Bool)`
   - Used to compare 2 rows of data and order them correctly.
   - If a **function** is passed, it must be **memoized**. The sortType function should return 1 if rowA is larger, and -1 if rowB is larger. `react-table` will take care of the rest.
-  - String options: `basic`, `datetime`, `alphanumeric`. Defaults to `alphanumeric`.
+  - String options: `string`, `number`, `basic`, `datetime`, `alphanumeric`. Defaults to `alphanumeric`.
   - The resolved function from the this string/function will be used to sort the this column's data.
     - If a `string` is passed, the function with that name located on either the custom `sortTypes` option or the built-in sorting types object will be used.
     - If a `function` is passed, it will be used.

--- a/docs/src/pages/docs/api/useTable.md
+++ b/docs/src/pages/docs/api/useTable.md
@@ -217,7 +217,7 @@ The following properties are available on every `Column` object returned by the 
   - This is the total width in pixels of all columns to the left of this column
   - Specifically useful when using plugin hooks that allow the user to resize column widths
 - `totalWidth: Int`
-  - This is the total width in pixels for this column (if it is a leaf-column) or or all of it's sub-columns (if it is a column group)
+  - This is the total width in pixels for this column (if it is a leaf-column) or or all of its sub-columns (if it is a column group)
   - Specifically useful when using plugin hooks that allow the user to resize column widths
 - `getHeaderProps: Function(?props)`
   - **Required**

--- a/docs/src/pages/docs/faq.md
+++ b/docs/src/pages/docs/faq.md
@@ -53,7 +53,7 @@ Using this approach, you can respond and trigger any type of side-effect using t
 
 ## How can I debounce rapid table state changes?
 
-React Table has a few built-in side-effects of it's own (most of which are meant for resetting parts of the state when `data` changes). By default, these state side-effects are on and when their conditions are met, they immediately fire off actions that will manipulate the table state. Sometimes, this may result in multiple rapid rerenders (usually just 2, or one more than normal), and could cause any side-effects you have watching the table state to also fire multiple times in-a-row. To alleviate this edge-case, React Table exports a `useAsyncDebounce` function that will allow you to debounce rapid side-effects and only use the latest one.
+React Table has a few built-in side-effects of its own (most of which are meant for resetting parts of the state when `data` changes). By default, these state side-effects are on and when their conditions are met, they immediately fire off actions that will manipulate the table state. Sometimes, this may result in multiple rapid rerenders (usually just 2, or one more than normal), and could cause any side-effects you have watching the table state to also fire multiple times in-a-row. To alleviate this edge-case, React Table exports a `useAsyncDebounce` function that will allow you to debounce rapid side-effects and only use the latest one.
 
 A good example of this when doing server-side pagination and sorting, a user changes the `sortBy` for a table and the `pageIndex` is automatically reset to `0` via an internal side effect. This would normally cause our effect below to fire 2 times, but with `useAsyncDebounce` we can make sure our data fetch function only gets called once:
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -15,7 +15,7 @@ const Home = () => {
     <>
       <Seo
         title="React Table"
-        description="Hooks for building lightweight, fast and extendable datagrids for React"
+        description="Hooks for building lightweight, fast and extendable datagrids for React. The best and most top-rated fully open-source table library for React!"
       />
       <Head>
         <title>

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -114,7 +114,7 @@ const Home = () => {
                     </h3>
                     <p className="mt-2  lg:mt-4 text-base xl:text-lg lg:leading-normal leading-6 text-gray-600">
                       Plugins are important for a healthy ecosystem, which is
-                      why React Table has it's very own plugin system allowing
+                      why React Table has its very own plugin system allowing
                       you to override or extend any logical step, stage or
                       process happening under the hood. Are you itching to build
                       your own row grouping and aggregation strategy? It's all

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -183,3 +183,65 @@ details > summary {
 
 @tailwind utilities;
 /* purgecss end ignore */
+
+#carbonads * {
+  margin: initial;
+  padding: initial;
+}
+#carbonads {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial,
+    sans-serif;
+}
+#carbonads {
+  display: flex;
+  max-width: 330px;
+  background-color: hsl(0, 0%, 98%);
+  box-shadow: 0 1px 4px 1px hsla(0, 0%, 0%, 0.1);
+  z-index: 100;
+}
+#carbonads a {
+  color: inherit;
+  text-decoration: none;
+}
+#carbonads a:hover {
+  color: inherit;
+}
+#carbonads span {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+#carbonads .carbon-wrap {
+  display: flex;
+}
+#carbonads .carbon-img {
+  display: block;
+  margin: 0;
+  line-height: 1;
+}
+#carbonads .carbon-img img {
+  display: block;
+}
+#carbonads .carbon-text {
+  font-size: 13px;
+  padding: 10px;
+  margin-bottom: 16px;
+  line-height: 1.5;
+  text-align: left;
+}
+#carbonads .carbon-poweredby {
+  display: block;
+  padding: 6px 8px;
+  background: #f1f1f2;
+  text-align: center;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  font-size: 8px;
+  line-height: 1;
+  border-top-left-radius: 3px;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -182,9 +182,6 @@ details > summary {
 }
 
 @tailwind utilities;
-/* purgecss end ignore */
-
-/* Why is this not showing up in prod? 👇 */
 
 #carbonads * {
   margin: initial;
@@ -247,3 +244,5 @@ details > summary {
   bottom: 0;
   right: 0;
 }
+
+/* purgecss end ignore */

--- a/docs/src/styles/index.css
+++ b/docs/src/styles/index.css
@@ -184,6 +184,8 @@ details > summary {
 @tailwind utilities;
 /* purgecss end ignore */
 
+/* Why is this not showing up in prod? 👇 */
+
 #carbonads * {
   margin: initial;
   padding: initial;

--- a/src/plugin-hooks/tests/useSortBy.test.js
+++ b/src/plugin-hooks/tests/useSortBy.test.js
@@ -155,6 +155,7 @@ function App({ useTableRef, initialState }) {
           {
             Header: 'First Name',
             accessor: 'firstName',
+            sortType: 'string'
           },
           {
             Header: 'Last Name',
@@ -168,6 +169,7 @@ function App({ useTableRef, initialState }) {
           {
             Header: 'Age',
             accessor: 'age',
+            sortType: 'number'
           },
           {
             Header: 'Visits',

--- a/src/plugin-hooks/useSortBy.js
+++ b/src/plugin-hooks/useSortBy.js
@@ -281,7 +281,7 @@ function useInstance(instance) {
       allColumns.find(col => col.id === sort.id)
     )
 
-    const sortData = rows => {
+    const sortData = (rows, parentRow = undefined) => {
       // Use the orderByFn to compose multiple sortBy's together.
       // This will also perform a stable sorting using the row index
       // if needed.
@@ -331,7 +331,8 @@ function useInstance(instance) {
           }
 
           return !sort.desc
-        })
+        }),
+        parentRow
       )
 
       // If there are sub-rows, sort them
@@ -340,7 +341,7 @@ function useInstance(instance) {
         if (!row.subRows || row.subRows.length === 0) {
           return
         }
-        row.subRows = sortData(row.subRows)
+        row.subRows = sortData(row.subRows, row)
       })
 
       return sortedData

--- a/src/sortTypes.js
+++ b/src/sortTypes.js
@@ -4,8 +4,8 @@ const reSplitAlphaNumeric = /([0-9]+)/gm
 // It handles numbers, mixed alphanumeric combinations, and even
 // null, undefined, and Infinity
 export const alphanumeric = (rowA, rowB, columnId) => {
-  let a = getRowValueByColumnID(rowA, columnId)
-  let b = getRowValueByColumnID(rowB, columnId)
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
+
   // Force to strings (or "" for unsupported types)
   a = toString(a)
   b = toString(b)
@@ -52,10 +52,8 @@ export const alphanumeric = (rowA, rowB, columnId) => {
 
   return a.length - b.length
 }
-
 export function datetime(rowA, rowB, columnId) {
-  let a = getRowValueByColumnID(rowA, columnId)
-  let b = getRowValueByColumnID(rowB, columnId)
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
 
   a = a.getTime()
   b = b.getTime()
@@ -64,8 +62,51 @@ export function datetime(rowA, rowB, columnId) {
 }
 
 export function basic(rowA, rowB, columnId) {
-  let a = getRowValueByColumnID(rowA, columnId)
-  let b = getRowValueByColumnID(rowB, columnId)
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
+
+  return compareBasic(a, b)
+}
+
+export function string(rowA, rowB, columnId) {
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
+
+  a = a.split('').filter(Boolean)
+  b = b.split('').filter(Boolean)
+
+  while (a.length && b.length) {
+    let aa = a.shift()
+    let bb = b.shift()
+
+    let alower = aa.toLowerCase()
+    let blower = bb.toLowerCase()
+
+    // Case insensitive comparison until characters match
+    if (alower > blower) {
+      return 1
+    }
+    if (blower > alower) {
+      return -1
+    }
+    // If lowercase characters are identical
+    if (aa > bb) {
+      return 1
+    }
+    if (bb > aa) {
+      return -1
+    }
+    continue
+  }
+
+  return a.length - b.length
+}
+
+export function number(rowA, rowB, columnId) {
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
+
+  const replaceNonNumeric = /[^0-9.]/gi
+
+  a = Number(String(a).replace(replaceNonNumeric, ''))
+  b = Number(String(b).replace(replaceNonNumeric, ''))
 
   return compareBasic(a, b)
 }
@@ -76,8 +117,8 @@ function compareBasic(a, b) {
   return a === b ? 0 : a > b ? 1 : -1
 }
 
-function getRowValueByColumnID(row, columnId) {
-  return row.values[columnId]
+function getRowValuesByColumnID(row1, row2, columnId) {
+  return [row1.values[columnId], row2.values[columnId]]
 }
 
 function toString(a) {


### PR DESCRIPTION
This PR allows `useSortBy`'s `orderBy` function to access the parent of the rows
being currently sorted via a new fourth positional parameter.

To enable this feature, it also adds a `parentRow` second parameter to the
internal `sortBy` function which is populated on recursive calls.

This feature allows developers to much more easily add a custom `orderBy` that 
selectively excludes rows based on depth, or any other property of their parent. 
I'm running into this use case right now, actually.

The PR also includes a docs change that adds the signature of `orderByFn` to the
header of its entry.
