### PR TITLE
Incorrect number of results in message

### DIFF
--- a/examples/filtering/src/App.js
+++ b/examples/filtering/src/App.js
@@ -310,7 +310,7 @@ function Table({ columns, data }) {
         </tbody>
       </table>
       <br />
-      <div>Showing the first 10 results of {rows.length} rows</div>
+      <div>Showing the first {firstPageRows.length} results of {rows.length} rows</div>
       <div>
         <pre>
           <code>{JSON.stringify(state.filters, null, 2)}</code>

--- a/examples/filtering/src/App.js
+++ b/examples/filtering/src/App.js
@@ -310,7 +310,7 @@ function Table({ columns, data }) {
         </tbody>
       </table>
       <br />
-      <div>Showing the first 20 results of {rows.length} rows</div>
+      <div>Showing the first 10 results of {rows.length} rows</div>
       <div>
         <pre>
           <code>{JSON.stringify(state.filters, null, 2)}</code>


### PR DESCRIPTION
While looking at this filtering example, I noticed that only the first 10 rows are displayed due to the following code.

https://github.com/tannerlinsley/react-table/blob/f97fb98509d0b27cc0bebcf3137872afe4f2809e/examples/filtering/src/App.js#L267

This PR just fixes the message so that it reflects the actual number of rows that are displayed.