### PR TITLE
Documents the autoResetResize property

### DIFF
--- a/docs/src/pages/docs/api/useResizeColumns.md
+++ b/docs/src/pages/docs/api/useResizeColumns.md
@@ -10,6 +10,9 @@
 - `disableResizing: Bool`
   - Defaults to `false`
   - When set to `true`, resizing is disabled across the entire table
+- `autoResetResize: Bool`
+  - Defaults to `true`
+  - When set to `true`, auto-resets column sizes whenever the useTable properties change
 
 ### Column Options
 


### PR DESCRIPTION
Adds documentation for the `autoResetResize` property used by the `useResizeColumns` plugin hook.