### PR TITLE
fix(useFilters): memoize column.setFilter

### DIFF
--- a/src/plugin-hooks/useFilters.js
+++ b/src/plugin-hooks/useFilters.js
@@ -152,6 +152,19 @@ function useInstance(instance) {
     [dispatch]
   )
 
+  // Memoized per column setFilter
+  const columnSetFilters = React.useMemo(
+    () =>
+      allColumns.reduce(
+        (setFilterDict, { id }) => ({
+          ...setFilterDict,
+          [id]: val => setFilter(id, val),
+        }),
+        {}
+      ),
+    [setFilter, allColumns]
+  )
+
   allColumns.forEach(column => {
     const {
       id,
@@ -170,7 +183,7 @@ function useInstance(instance) {
       : getFirstDefined(columnDefaultCanFilter, defaultCanFilter, false)
 
     // Provide the column a way of updating the filter value
-    column.setFilter = val => setFilter(column.id, val)
+    column.setFilter = columnSetFilters[id]
 
     // Provide the current filter value to the column for
     // convenience


### PR DESCRIPTION
Close #3129 
Use a memoized dict containing allColumn ids as key pointing with a per column setFilter function (as using a useCallback inside allColumn.forEach breaks the [rule of hooks](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level))