### PR TITLE
docs(useSortBy): fix typo

### DIFF
--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -16,7 +16,7 @@ The following options are supported via the main options object passed to `useTa
 
 - `initialState.sortBy: Array<Object<id: columnId, desc: Bool = true>>`
   - Must be **memoized**
-  - An array of sorting objects. If there is more than one object in the array, multi-sorting will be enabled. Each sorting object should contain an `id` key with the corresponding column ID to sort by. An optional `desc` key (which defaults to `false`) may be set to `true` to indicate a descending sorting directionfor that column, otherwise, it will be assumed to be ascending. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
+  - An array of sorting objects. If there is more than one object in the array, multi-sorting will be enabled. Each sorting object should contain an `id` key with the corresponding column ID to sort by. An optional `desc` key (which defaults to `false`) may be set to `true` to indicate a descending sorting direction for that column, otherwise, it will be assumed to be ascending. This information is stored in state since the table is allowed to manipulate the filter through user interaction.
 - `manualSortBy: Bool`
   - Enables sorting detection functionality, but does not automatically perform row sorting. Turn this on if you wish to implement your own sorting outside of the table (eg. server-side or manual row grouping/nesting)
 - `disableSortBy: Bool`


### PR DESCRIPTION
Fix typo.

From `directionfor` to `direction for`.