### PR TITLE
Fix bug in text filters where null is incorrectly matched

### DIFF
--- a/src/filterTypes.js
+++ b/src/filterTypes.js
@@ -2,7 +2,7 @@ export const text = (rows, ids, filterValue) => {
   rows = rows.filter(row => {
     return ids.some(id => {
       const rowValue = row.values[id]
-      return String(rowValue)
+      return String(rowValue || '')
         .toLowerCase()
         .includes(String(filterValue).toLowerCase())
     })
@@ -17,7 +17,7 @@ export const exactText = (rows, ids, filterValue) => {
     return ids.some(id => {
       const rowValue = row.values[id]
       return rowValue !== undefined
-        ? String(rowValue).toLowerCase() === String(filterValue).toLowerCase()
+        ? String(rowValue || '').toLowerCase() === String(filterValue).toLowerCase()
         : true
     })
   })
@@ -30,7 +30,7 @@ export const exactTextCase = (rows, ids, filterValue) => {
     return ids.some(id => {
       const rowValue = row.values[id]
       return rowValue !== undefined
-        ? String(rowValue) === String(filterValue)
+        ? String(rowValue || '') === String(filterValue)
         : true
     })
   })


### PR DESCRIPTION
Text filters (text, exactText, and exactTextCase) incorrectly match null cell values when filterValue is the string "null".
This change coerces null to empty string before comparing to the filterValue to avoid the unexpected match.