### PR TITLE
perf(useResizeColumns): optimize dispatch count

### DIFF
--- a/src/plugin-hooks/tests/useResizeColumns.test.js
+++ b/src/plugin-hooks/tests/useResizeColumns.test.js
@@ -167,6 +167,14 @@ const sizesAfter = [
   '179.26829268292684px',
 ]
 
+beforeEach(() => {
+  jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb())
+})
+
+afterEach(() => {
+  window.requestAnimationFrame.mockRestore()
+})
+
 test('table can be resized by a mouse', () => {
   const rtl = render(<App />)
 

--- a/src/plugin-hooks/useResizeColumns.js
+++ b/src/plugin-hooks/useResizeColumns.js
@@ -52,12 +52,16 @@ const defaultGetResizerProps = (props, { instance, header }) => {
     let raf
     let mostRecentClientX
 
+    let counterA = 0
+    let counterB = 0
     const dispatchEnd = () => {
       window.cancelAnimationFrame(raf)
       raf = null
       dispatch({ type: actions.columnDoneResizing })
     }
     const dispatchMove = () => {
+      counterB++
+      console.log(counterA, counterB)
       window.cancelAnimationFrame(raf)
       raf = null
       dispatch({ type: actions.columnResizing, clientX: mostRecentClientX })
@@ -65,6 +69,7 @@ const defaultGetResizerProps = (props, { instance, header }) => {
 
     const scheduleDispatchMoveOnNextAnimationFrame = clientXPos => {
       mostRecentClientX = clientXPos
+      counterA++
       if (!raf) {
         raf = window.requestAnimationFrame(dispatchMove)
       }

--- a/src/plugin-hooks/useResizeColumns.js
+++ b/src/plugin-hooks/useResizeColumns.js
@@ -52,16 +52,12 @@ const defaultGetResizerProps = (props, { instance, header }) => {
     let raf
     let mostRecentClientX
 
-    let counterA = 0
-    let counterB = 0
     const dispatchEnd = () => {
       window.cancelAnimationFrame(raf)
       raf = null
       dispatch({ type: actions.columnDoneResizing })
     }
     const dispatchMove = () => {
-      counterB++
-      console.log(counterA, counterB)
       window.cancelAnimationFrame(raf)
       raf = null
       dispatch({ type: actions.columnResizing, clientX: mostRecentClientX })
@@ -69,7 +65,6 @@ const defaultGetResizerProps = (props, { instance, header }) => {
 
     const scheduleDispatchMoveOnNextAnimationFrame = clientXPos => {
       mostRecentClientX = clientXPos
-      counterA++
       if (!raf) {
         raf = window.requestAnimationFrame(dispatchMove)
       }


### PR DESCRIPTION
👋 hey internet, here's an optimization that significantly improves column resize performance

- i'm consistently seeing a 30-50% reduction in the number of calls to `dispatch()` when i interactively drag the handle back and forth in the "column-resizing" demo
- want to debug this even farther locally or on codesandbox?
  - this commit demonstrates how to add some console statements to show the number of calls: 37a69f5
  - you can pull this branch and revert that commit to measure this interactively yourself if you want to
- partially addresses #3165