### PR TITLE
fix(useResizeColumns): don't ignore header width = 0

### DIFF
--- a/src/plugin-hooks/useResizeColumns.js
+++ b/src/plugin-hooks/useResizeColumns.js
@@ -230,10 +230,12 @@ const useInstanceBeforeDimensions = instance => {
     )
 
     header.canResize = canResize
+
+    const width = columnResizing.columnWidths[header.id]
+
     header.width =
-      columnResizing.columnWidths[header.id] ||
-      header.originalWidth ||
-      header.width
+      typeof width === 'number' ? width : header.originalWidth || header.width
+
     header.isResizing = columnResizing.isResizingColumn === header.id
 
     if (canResize) {


### PR DESCRIPTION
When the user resizes a column to min width and translates the cursor to the nearest column, the column size does not remain equal to the min width but "jumps" back to the default column width.

In this PR I just split the check to number and other data type (e.g `undefined`) because `0` was ignored.

Before: 

https://user-images.githubusercontent.com/9784329/118188085-8b247780-b448-11eb-9796-358b87d3396a.mov

After:

https://user-images.githubusercontent.com/9784329/118187718-fde12300-b447-11eb-86d8-57021c01083d.mov