### PR TITLE
fix(deps): include babel runtime in build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
     ],
     "@babel/react"
   ],
+  "plugins": ["@babel/plugin-transform-runtime"],
   "env": {
     "test": {
       "presets": ["@babel/preset-env", "@babel/react"],

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.13.0",
     "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.3.3",
+    "@rollup/plugin-babel": "^5.3.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-peer-deps-external": "^2.2.0",
@@ -108,5 +108,8 @@
     "rollup-plugin-size-snapshot": "^0.10.0",
     "rollup-plugin-terser": "^5.1.2",
     "serve": "^11.2.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.7.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,4 @@
-import babel from 'rollup-plugin-babel'
+import { babel } from '@rollup/plugin-babel'
 import { terser } from 'rollup-plugin-terser'
 import size from 'rollup-plugin-size'
 import externalDeps from 'rollup-plugin-peer-deps-external'
@@ -23,7 +23,7 @@ export default [
     external,
     plugins: [
       replace({ 'process.env.NODE_ENV': `"development"`, delimiters: ['', ''] }),
-      babel(),
+      babel({ babelHelpers: 'runtime' }),
       externalDeps(),
     ],
   },
@@ -39,7 +39,7 @@ export default [
     external,
     plugins: [
       replace({ 'process.env.NODE_ENV': `"production"`, delimiters: ['', ''] }),
-      babel(),
+      babel({ babelHelpers: 'runtime' }),
       externalDeps(),
       terser(),
       size({


### PR DESCRIPTION
This updates the Rollup Babel plugin and also includes the Babel runtime in the final build, as recommended by Babel. The Rollup Babel plugin has babelHelpers set to "runtime", which is recommended for libraries in the plugin documentation.

https://www.npmjs.com/package/@rollup/plugin-babel

This is necessary for anyone using a tooling setup that does not include Babel out of the box. For instance Vite, etc.

## Reasoning

I was running into this error:

```
Uncaught ReferenceError: regeneratorRuntime is not defined
```

Specifically with useAsyncDebounce.