### PR TITLE
fix: handle non-string values when sorting strings

### DIFF
--- a/src/sortTypes.js
+++ b/src/sortTypes.js
@@ -70,8 +70,12 @@ export function basic(rowA, rowB, columnId) {
 export function string(rowA, rowB, columnId) {
   let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
 
-  a = a.split('').filter(Boolean)
-  b = b.split('').filter(Boolean)
+  a = a?.toString().split('').filter(Boolean)
+  b = b?.toString().split('').filter(Boolean)
+
+  if(!a && !b) return 0;
+  if(a && !b) return 1;
+  if(!a && b) return -1;
 
   while (a.length && b.length) {
     let aa = a.shift()

--- a/src/sortTypes.test.js
+++ b/src/sortTypes.test.js
@@ -1,0 +1,53 @@
+import { string } from './sortTypes'
+
+/**
+ * Creates a sample row compatible with sortTypes
+ * @param {any} value
+ * @param {string} columnId
+ * @returns {Object}
+ */
+function createSampleRow(value, columnId='target'){
+  return {
+    values: {
+      [columnId]: value
+    }
+  }
+};
+
+describe('string sorting', () => {
+  test.each([
+    ['a', 'b', -1],
+    ['b', 'c', -1],
+    ['z', 'a', 1],
+    ['@', '@', 0]
+  ])('should sort string values', (a, b, expected) => {
+    expect(
+      string(
+        createSampleRow(a),
+        createSampleRow(b),
+        'target'
+      )
+    ).toBe(expected)
+  })
+  test.each([
+    [1, 1, 0],
+    [1,2, -1],
+    [2,1, 1],
+    [true, true, 0],
+    [new Date('2021-01-01T00:00:00Z'), new Date('2021-01-01T00:00:01Z'), -1],
+    [{}, {}, 0],
+    [undefined, undefined, 0],
+    [null, null, 0],
+    [1, null, 1],
+    [null, 1, -1],
+    [null, undefined, 0]
+  ])('should handle invalid string values', (a, b, expected) => {
+    expect(
+      string(
+        createSampleRow(a),
+        createSampleRow(b),
+        'target'
+      )
+    ).toBe(expected)
+  })
+})


### PR DESCRIPTION
It crashes if a non-string value is provided when using `string` sortType, this fix avoid it.