### PR TITLE
add v6 peer dependency support for react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.0",
-    "react": "^16.x.x",
-    "react-dom": "^16.x.x"
+    "react": "^17.x.x",
+    "react-dom": "^17.x.x"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.0",
-    "react": "^17.x.x",
-    "react-dom": "^17.x.x"
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.0",


### PR DESCRIPTION
This should allow `react-table-6` to be installed with React 17. Would it be possible to get this merged and distributed as a new version in the `react-table-6` lib?