### PR TITLE
fix: allow different maximum depths without duplicating an ancestor

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,8 +11,10 @@ export function findMaxDepth(columns, depth = 0) {
 }
 
 // Build the visible columns, headers and flat column list
-export function linkColumnStructure(columns, parent, depth = 0) {
+export function linkColumnStructure(columns, parent, depth = 0, maxDepth = 0) {
   return columns.map(column => {
+    const deepest =
+      !depth && column.columns ? findMaxDepth(column.columns) + 1 : maxDepth
     column = {
       ...column,
       parent,
@@ -21,8 +23,25 @@ export function linkColumnStructure(columns, parent, depth = 0) {
 
     assignColumnAccessor(column)
 
+    const newDepth = depth + 1
+
     if (column.columns) {
-      column.columns = linkColumnStructure(column.columns, column, depth + 1)
+      column.columns = linkColumnStructure(
+        column.columns,
+        column,
+        newDepth,
+        deepest
+      )
+    } else if (deepest > depth) {
+      const nextCol = { ...column }
+      column = {
+        parent,
+        depth,
+        Header: '',
+        id: column.id + '_previous_placeholder',
+        placeholderOf: column,
+      }
+      column.columns = linkColumnStructure([nextCol], column, newDepth, deepest)
     }
     return column
   })


### PR DESCRIPTION
Add a placeholder column above columns without children that share an ancestor with columns that have larger depth to remove the duplication of the ancestor label.

Before
![before](https://user-images.githubusercontent.com/3683420/128798495-5afb6755-9823-4fc4-b8c0-93b8cf379035.png)

Now:
![after](https://user-images.githubusercontent.com/3683420/128798409-c1837a13-46bc-4b61-9c67-68522a0f15eb.png)

Notice the info is there only once at  the top and the columns are neatly placed.
