### PR TITLE
fix: check for row existence in handleRowById

### DIFF
--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -154,16 +154,18 @@ function reducer(state, action, previousState, instance) {
     const handleRowById = id => {
       const row = rowsById[id]
 
-      if (!row.isGrouped) {
-        if (shouldExist) {
-          newSelectedRowIds[id] = true
-        } else {
-          delete newSelectedRowIds[id]
+      if (row) {
+        if (!row.isGrouped) {
+          if (shouldExist) {
+            newSelectedRowIds[id] = true
+          } else {
+            delete newSelectedRowIds[id]
+          }
         }
-      }
 
-      if (selectSubRows && getSubRows(row)) {
-        return getSubRows(row).forEach(row => handleRowById(row.id))
+        if (selectSubRows && getSubRows(row)) {
+          return getSubRows(row).forEach(row => handleRowById(row.id))
+        }
       }
     }
 


### PR DESCRIPTION
This will fix the errors referenced by #2833 and #3071. This will also fix a "TypeError: Cannot read property 'subRows' of undefined" error. These errors appear when a row does not exist, whether removed from the data or filtered out, but there is still a reference in the selected state.