### PR TITLE
Sample code fix for page index resetting during manual pagination

### DIFF
--- a/examples/pagination-controlled/src/App.js
+++ b/examples/pagination-controlled/src/App.js
@@ -73,6 +73,7 @@ function Table({
       // This means we'll also have to provide our own
       // pageCount.
       pageCount: controlledPageCount,
+      autoResetPage: false,
     },
     usePagination
   )


### PR DESCRIPTION
# Description
- Based on the example code fetchData will be called twice, and during the second call, the pageIndex will be set to zero.
- In order to prevent resetting of the pageIndex, the `autoResetPage` should be set to `false` to simulate a proper server-side rendering.
- Related issue: #411