### PR TITLE
fix: table crash when data is null or undefined

### DIFF
--- a/src/hooks/useTable.js
+++ b/src/hooks/useTable.js
@@ -588,7 +588,7 @@ function accessRowsForColumn({
     )
   }
 
-  data.forEach((originalRow, rowIndex) =>
+  data?.forEach((originalRow, rowIndex) =>
     accessRow(originalRow, rowIndex, 0, undefined, rows)
   )
 }


### PR DESCRIPTION
This PR provides a fix for situation when tabledata is undefined or null,the table will crash with error 'TypeError: Cannot read property 'forEach' of undefined'
