### PR TITLE
fix(useRowSelect): do not throw if toggleRowSelected id not found in current instance

### DIFF
--- a/src/plugin-hooks/tests/useRowSelect.test.js
+++ b/src/plugin-hooks/tests/useRowSelect.test.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { useTable } from '../../hooks/useTable'
-import { useRowSelect } from '../useRowSelect'
+import { useRowSelect, reducer } from '../useRowSelect'
 import { useExpanded } from '../useExpanded'
 import { usePagination } from '../usePagination'
+import { actions } from '../../publicUtils'
 
 const dataPiece = [
   {
@@ -381,4 +382,27 @@ test('renders a table with selectable rows, only selecting the current page', ()
   fireEvent.click(rtl.getByLabelText('Select All'))
 
   expect(rtl.queryAllByText('Selected').length).toBe(0)
+})
+
+describe('reducer', () => {
+  describe('toggleRowSelected', () => {
+    test('does not throw when row not found', () => {
+      const state = { selectedRowIds: {2: true, 3: true} }
+      const action = {
+        type: actions.toggleRowSelected,
+        value: false,
+        id: 1
+      }
+      const instance = {
+        rowsById: {},
+        selectSubRows: true,
+        getSubRows: () => {}
+      }
+      expect(() => {
+        const { selectedRowIds } = reducer(state, action, undefined, instance)
+        expect(selectedRowIds['2']).toBe(true)
+        expect(selectedRowIds['3']).toBe(true)
+      }).not.toThrow()
+    })
+  })
 })

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -92,7 +92,7 @@ const defaultGetToggleAllPageRowsSelectedProps = (props, { instance }) => [
 ]
 
 // eslint-disable-next-line max-params
-function reducer(state, action, previousState, instance) {
+export function reducer(state, action, previousState, instance) {
   if (action.type === actions.init) {
     return {
       selectedRowIds: {},
@@ -153,6 +153,7 @@ function reducer(state, action, previousState, instance) {
 
     const handleRowById = id => {
       const row = rowsById[id]
+      if (row === undefined) return
 
       if (!row.isGrouped) {
         if (shouldExist) {


### PR DESCRIPTION
Encountered an exception when a component callback held reference to a row that was deleted by the time it was executed. This PR adds a small change to bail early in the reducer if the `toggleRowSelected` action's row id is not found in the current instance.