### PR TITLE
docs: fix missing variable in README example

### DIFF
--- a/examples/pagination/README.md
+++ b/examples/pagination/README.md
@@ -85,7 +85,7 @@ function MyTable(props) {
 +           setPageSize(Number(e.target.value))
 +         }}
 +       >
-+         {pageSizeOptions.map(pageSize => (
++         {[10, 20, 30, 40, 50].map(pageSize => (
 +           <option key={pageSize} value={pageSize}>
 +             Show {pageSize}
 +           </option>


### PR DESCRIPTION
Fixes a missing variable from the example.

`pageSizeOptions` isn't anywhere else in the example. I copied the values from the Codesandbox to replace it.