### PR TITLE
fix(useExpanded): state of isAllRowsExpanded on React.StrictMode

### DIFF
--- a/src/plugin-hooks/useExpanded.js
+++ b/src/plugin-hooks/useExpanded.js
@@ -69,7 +69,10 @@ function reducer(state, action, previousState, instance) {
 
   if (action.type === actions.toggleAllRowsExpanded) {
     const { value } = action
-    const { isAllRowsExpanded, rowsById } = instance
+    const { rowsById } = instance
+
+    const isAllRowsExpanded =
+      Object.keys(rowsById).length === Object.keys(state.expanded).length
 
     const expandAll = typeof value !== 'undefined' ? value : !isAllRowsExpanded
 


### PR DESCRIPTION
#3061 mentions below.

> When using React.StricttMode you are unable to collapse all rows using the "expand/collapse all" button after expanding them. This can be seen in the React Table "Expanding" official example just by running the app in strict mode.
> https://codesandbox.io/s/exciting-bartik-hrbeu?file=/src/index.js

I change `isAllRowsExpanded` from `instance` to recalculating it by using `state` because `isAllRowsExpanded` from `instance` is toggled twice on React.StrictMode. Once `isAllRowsExpanded` from `instance` gets `true`, it toggles twice and always returns `true` whenever the "Toggle All Rows Expanded" button is clicked.  

**Test result**

```bash
 PASS   unit  src/plugin-hooks/tests/useExpanded.test.js
  ✓ renders an expandable table (91ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        3.615s
Ran all test suites matching /src\/plugin-hooks\/tests\/useExpanded\.test\.js/i.
```
**Applied example**

https://github.com/yhor1e/react-table-fix-state-of-isallrowsexpanded-on-strictmode

In the above repository, I applied this PR to the [expanding example](https://github.com/tannerlinsley/react-table/tree/8c77b4ad97353a0b1f0746be5b919868862a9dcc/examples/expanding).

Please check this PR. Thanks.