### PR TITLE
feat: add support for shift-selecting rows

### DIFF
--- a/docs/src/pages/docs/api/useRowSelect.md
+++ b/docs/src/pages/docs/api/useRowSelect.md
@@ -3,7 +3,7 @@
 - Plugin Hook
 - Optional
 
-`useRowSelect` is the hook that implements **basic row selection**. For more information on row selection, see Row Selection
+`useRowSelect` is the hook that implements **basic row selection**. It supports the selection of a range of rows with the shift key modifier. For more information on row selection, see Row Selection
 
 ### Table Options
 
@@ -28,6 +28,8 @@ The following options are supported via the main options object passed to `useTa
 
 The following values are provided to the table `instance`:
 
+- `state.lastSelectedRowId: rowId | null`
+  - The id of the row that last was selected.
 - `toggleRowSelected: Function(rowPath: String, ?set: Bool) => void`
   - Use this function to toggle a row's selected state.
   - Optionally pass `true` or `false` to set it to that state

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -104,6 +104,7 @@ function reducer(state, action, previousState, instance) {
     return {
       ...state,
       selectedRowIds: instance.initialState.selectedRowIds || {},
+      lastSelectedRowId: null,
     }
   }
 

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -174,8 +174,8 @@ function reducer(state, action, previousState, instance) {
       const currentIndex = rows.findIndex(row => row.id === id)
       const startIndex = Math.min(previousIndex, currentIndex)
       const endIndex = Math.max(previousIndex, currentIndex)
-      const rowIdsToToggle = rows.slice(startIndex, endIndex + 1)
-      rowIdsToToggle.forEach(row => handleRowById(row.id))
+      const rowsToToggle = rows.slice(startIndex, endIndex + 1)
+      rowsToToggle.forEach(row => handleRowById(row.id))
     } else {
       handleRowById(id)
     }

--- a/src/plugin-hooks/useRowSelect.js
+++ b/src/plugin-hooks/useRowSelect.js
@@ -96,7 +96,6 @@ function reducer(state, action, previousState, instance) {
     return {
       selectedRowIds: {},
       lastSelectedRowId: null,
-      lastShiftSelectedRowId: null,
       ...state,
     }
   }
@@ -175,11 +174,8 @@ function reducer(state, action, previousState, instance) {
       const currentIndex = rows.findIndex(row => row.id === id)
       const startIndex = Math.min(previousIndex, currentIndex)
       const endIndex = Math.max(previousIndex, currentIndex)
-      const rowIdsToToggle = Object.keys(rowsById).slice(
-        startIndex,
-        endIndex + 1
-      )
-      rowIdsToToggle.forEach(id => handleRowById(id))
+      const rowIdsToToggle = rows.slice(startIndex, endIndex + 1)
+      rowIdsToToggle.forEach(row => handleRowById(row.id))
     } else {
       handleRowById(id)
     }


### PR DESCRIPTION
Add functionality to select or deselect the range of rows
between the previously and currently selected row. Matches
functionality found in services like gmail