### PR TITLE
fix(useSortBy): allow null values in string sort

### DIFF
--- a/src/sortTypes.js
+++ b/src/sortTypes.js
@@ -70,6 +70,14 @@ export function basic(rowA, rowB, columnId) {
 export function string(rowA, rowB, columnId) {
   let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId)
 
+  // Handle cases where one or both are null, undefined or empty.
+  if (!a) {
+    return b ? -1 : 0
+  }
+  if (!b) {
+    return 1
+  }
+
   a = a.split('').filter(Boolean)
   b = b.split('').filter(Boolean)
 


### PR DESCRIPTION
Fixes fatal error `TypeError Cannot read property 'split' of null` described in issue #3269 by exiting early if either string in the sort comparer is `null` or `undefined`.

The empty values will appear at the top when the sort is ascending and at the bottom when descending.  [Demo of behavior](https://codesandbox.io/s/mutable-wildflower-dqq67?file=/src/App.js).

I would love some feedback on what the "correct" order should be.  Personally I would prefer to put empty values at the bottom when sorted ascending (reversing the `1` and `-1` return values).  However I wanted this to be a non-breaking change.  Putting them at the top is consistent with how empty strings are currently sorted.