### PR TITLE
fix(useGridLayout): Support header groups

### DIFF
--- a/docs/src/pages/docs/api/overview.md
+++ b/docs/src/pages/docs/api/overview.md
@@ -28,6 +28,7 @@ React Table is essentially a compatible collection of **custom React hooks**:
     - `useBlockLayout`
     - `useAbsoluteLayout`
     - `useFlexLayout`
+    - `useGridLayout`
 - 3rd Party Plugin Hooks
   - [LineUp-lite Hooks](https://lineup-lite.netlify.app)
     - Core Plugin Hooks

--- a/docs/src/pages/docs/api/useGridLayout.md
+++ b/docs/src/pages/docs/api/useGridLayout.md
@@ -10,3 +10,14 @@
 - `getTableProps`
   - **Usage Required**
   - This core prop getter is required to get the correct stying for the layout
+
+### Row Properties
+
+- `getRowProps`
+  - This core prop getter is required for rendering sub-components as a full row
+
+### Header Properties
+
+- `getHeaderProps`
+  - **Usage Required**
+  - This core prop getter is required to to enable absolute layout for headers

--- a/src/plugin-hooks/tests/useGridLayout.test.js
+++ b/src/plugin-hooks/tests/useGridLayout.test.js
@@ -31,36 +31,45 @@ const data = [
 ]
 
 function Table({ columns, data }) {
-  const {
-    getTableProps,
-    headerGroups,
-    rows,
-    prepareRow,
-  } = useTable(
+    const defaultColumn = React.useMemo(
+      () => ({
+        minWidth: 30,
+        width: 'auto',
+        maxWidth: 400,
+      }),
+      []
+    )
+
+  const { getTableProps, headerGroups, rows, prepareRow } = useTable(
     {
       columns,
       data,
+      defaultColumn,
     },
-    useGridLayout,
+    useGridLayout
   )
 
   return (
     <div {...getTableProps()} className="table">
-      {headerGroups.map(headerGroup => (
+      {headerGroups.map(headerGroup =>
         headerGroup.headers.map(column => (
-          <div key={column.id} {...column.getHeaderProps()} className="cell header">
+          <div
+            key={column.id}
+            {...column.getHeaderProps()}
+            className="cell header"
+          >
             {column.render('Header')}
           </div>
         ))
-      ))}
-      {rows.map(row => 
-        prepareRow(row) || (
+      )}
+      {rows.map(
+        row =>
+          prepareRow(row) ||
           row.cells.map(cell => (
             <div {...cell.getCellProps()} className="cell">
               {cell.render('Cell')}
             </div>
           ))
-        )
       )}
     </div>
   )
@@ -70,28 +79,42 @@ function App() {
   const columns = React.useMemo(
     () => [
       {
-        Header: 'First Name',
-        accessor: 'firstName',
+        Header: 'Name',
+        columns: [
+          {
+            Header: 'First Name',
+            accessor: 'firstName',
+            width: 'auto',
+          },
+          {
+            Header: 'Last Name',
+            accessor: 'lastName',
+            width: 350,
+          },
+        ],
       },
       {
-        Header: 'Last Name',
-        accessor: 'lastName',
-      },
-      {
-        Header: 'Age',
-        accessor: 'age',
-      },
-      {
-        Header: 'Visits',
-        accessor: 'visits',
-      },
-      {
-        Header: 'Status',
-        accessor: 'status',
-      },
-      {
-        Header: 'Profile Progress',
-        accessor: 'progress',
+        Header: 'Info',
+        columns: [
+          {
+            Header: 'Age',
+            accessor: 'age',
+            minWidth: 300,
+          },
+          {
+            Header: 'Visits',
+            accessor: 'visits',
+            maxWidth: 150,
+          },
+          {
+            Header: 'Status',
+            accessor: 'status',
+          },
+          {
+            Header: 'Profile Progress',
+            accessor: 'progress',
+          },
+        ],
       },
     ],
     []
@@ -106,6 +129,6 @@ test('renders a table', () => {
   const [table] = rendered.queryAllByRole('table')
 
   expect(table.getAttribute('style')).toEqual(
-    'display: grid; grid-template-columns: auto auto auto auto auto auto;'
+    'display: grid; grid-template-columns: auto 350px auto auto auto auto;'
   )
 })

--- a/src/plugin-hooks/useGridLayout.js
+++ b/src/plugin-hooks/useGridLayout.js
@@ -1,54 +1,128 @@
+import { actions } from '../publicUtils'
+
+// Actions
+actions.columnStartResizing = 'columnStartResizing'
+actions.columnResizing = 'columnResizing'
+actions.columnDoneResizing = 'columnDoneResizing'
+actions.resetResize = 'resetResize'
+
 export function useGridLayout(hooks) {
   hooks.stateReducers.push(reducer)
   hooks.getTableProps.push(getTableProps)
   hooks.getHeaderProps.push(getHeaderProps)
+  hooks.getRowProps.push(getRowProps)
 }
 
 useGridLayout.pluginName = 'useGridLayout'
 
-const getTableProps = (props, { instance }) => [
-  props,
-  {
-    style: {
-      display: `grid`,
-      gridTemplateColumns: instance.state.gridLayout.columnWidths.map(w => w).join(` `),
+const getTableProps = (props, { instance }) => {
+  const gridTemplateColumns = instance.visibleColumns.map(column => {
+    if (instance.state.gridLayout.columnWidths[column.id])
+      return `${instance.state.gridLayout.columnWidths[column.id]}px`
+    // When resizing, lock the width of all unset columns
+    // instead of using user-provided width or defaultColumn width,
+    // which could potentially be 'auto' or 'fr' units that don't scale linearly
+    if (instance.state.columnResizing?.isResizingColumn)
+      return `${instance.state.gridLayout.startWidths[column.id]}px`
+    if (typeof column.width === 'number') return `${column.width}px`
+    return column.width
+  })
+  return [
+    props,
+    {
+      style: {
+        display: `grid`,
+        gridTemplateColumns: gridTemplateColumns.join(` `),
+      },
     },
-  },
-]
+  ]
+}
 
 const getHeaderProps = (props, { column }) => [
   props,
   {
     id: `header-cell-${column.id}`,
     style: {
-      position: `sticky` //enables a scroll wrapper to be placed around the table and have sticky headers
+      position: `sticky`, //enables a scroll wrapper to be placed around the table and have sticky headers
+      gridColumn: `span ${column.totalVisibleHeaderCount}`,
     },
   },
 ]
 
+const getRowProps = (props, { row }) => {
+  if (row.isExpanded) {
+    return [
+      props,
+      {
+        style: {
+          gridColumn: `1 / ${row.cells.length + 1}`,
+        },
+      },
+    ]
+  }
+  return [props, {}]
+}
+
 function reducer(state, action, previousState, instance) {
-  if (action.type === `init`) {
+  if (action.type === actions.init) {
     return {
       gridLayout: {
-        columnWidths: instance.columns.map(() => `auto`),
+        columnWidths: {},
       },
       ...state,
     }
   }
 
-  if (action.type === `columnStartResizing`) {
-    const { columnId } = action
-    const columnIndex = instance.visibleColumns.findIndex(col => col.id === columnId)
-    const elWidth = getElementWidth(columnId)
+  if (action.type === actions.resetResize) {
+    return {
+      ...state,
+      gridLayout: {
+        columnWidths: {},
+      },
+    }
+  }
 
-    if (elWidth !== undefined) {
+  if (action.type === actions.columnStartResizing) {
+    const { columnId, headerIdWidths } = action
+    const columnWidth = getElementWidth(columnId)
+
+    if (columnWidth !== undefined) {
+      const startWidths = instance.visibleColumns.reduce(
+        (acc, column) => ({
+          ...acc,
+          [column.id]: getElementWidth(column.id),
+        }),
+        {}
+      )
+      const minWidths = instance.visibleColumns.reduce(
+        (acc, column) => ({
+          ...acc,
+          [column.id]: column.minWidth,
+        }),
+        {}
+      )
+      const maxWidths = instance.visibleColumns.reduce(
+        (acc, column) => ({
+          ...acc,
+          [column.id]: column.maxWidth,
+        }),
+        {}
+      )
+
+      const headerIdGridWidths = headerIdWidths.map(([headerId]) => [
+        headerId,
+        getElementWidth(headerId),
+      ])
+
       return {
         ...state,
         gridLayout: {
           ...state.gridLayout,
-          columnId,
-          columnIndex,
-          startingWidth: elWidth
+          startWidths,
+          minWidths,
+          maxWidths,
+          headerIdGridWidths,
+          columnWidth,
         },
       }
     } else {
@@ -56,23 +130,51 @@ function reducer(state, action, previousState, instance) {
     }
   }
 
-  if (action.type === `columnResizing`) {
+  if (action.type === actions.columnResizing) {
+    const { clientX } = action
+    const { startX } = state.columnResizing
     const {
-      columnIndex,
-      startingWidth,
-      columnWidths,
+      columnWidth,
+      minWidths,
+      maxWidths,
+      headerIdGridWidths = [],
     } = state.gridLayout
 
-    const change = state.columnResizing.startX - action.clientX
-    const newWidth = startingWidth - change
-    const columnWidthsCopy = [...columnWidths]
-    columnWidthsCopy[columnIndex] = `${newWidth}px`
+    const deltaX = clientX - startX
+    const percentageDeltaX = deltaX / columnWidth
+
+    const newColumnWidths = {}
+
+    headerIdGridWidths.forEach(([headerId, headerWidth]) => {
+      newColumnWidths[headerId] = Math.min(
+        Math.max(
+          minWidths[headerId],
+          headerWidth + headerWidth * percentageDeltaX
+        ),
+        maxWidths[headerId]
+      )
+    })
 
     return {
       ...state,
       gridLayout: {
         ...state.gridLayout,
-        columnWidths: columnWidthsCopy,
+        columnWidths: {
+          ...state.gridLayout.columnWidths,
+          ...newColumnWidths,
+        },
+      },
+    }
+  }
+
+  if (action.type === actions.columnDoneResizing) {
+    return {
+      ...state,
+      gridLayout: {
+        ...state.gridLayout,
+        startWidths: {},
+        minWidths: {},
+        maxWidths: {},
       },
     }
   }


### PR DESCRIPTION
### Header Groups Bug
Resolves #3537 

`useGridLayout` could not display header groups by default. This seemed like a bug as it is fairly common functionality that it should be able to handle.

Header groups can be supported with the grid layout by using the css grid-column property with a span of the column's `totalVisibleHeaderCount`.

### Column Resizing Bug
`useGridLayout` has a bug that comes from 'auto' or 'fr' units. When some resizing columns, the cursor doesn't stay with the resizer handle because 'auto' width columns rescale based on the column being resized. e.g. columnResizing state thinks the column width is 150, but it is actually 200 because of grid 'auto' resizing.

This column resizing bug was fixed by locking the width of all columns not being resized. Now, while resizing, this behaves exactly like the Resizing example (with `useBlockLayout`). After resizing, all columns that have not been resized will default back to their previous value. As a bonus, this supports user-provided 'width' values on columns. If 'auto' width columns is desired (instead of the default 150), that can be set with the defaultColumn useTable prop.

`useGridLayout` also had a bug where columns could be resized beyond the minWidth and maxWidth values. These values are now taken into account when resizing. However, this MR does not apply minWidth and maxWidth during initial column sizing.