### PR TITLE
Use provided column `width` when creating grid layout

### DIFF
--- a/src/plugin-hooks/useGridLayout.js
+++ b/src/plugin-hooks/useGridLayout.js
@@ -30,7 +30,14 @@ function reducer(state, action, previousState, instance) {
   if (action.type === `init`) {
     return {
       gridLayout: {
-        columnWidths: instance.columns.map(() => `auto`),
+        columnWidths: instance.columns.map((column, index) => {
+          // If column width is defined, use it instead of `auto`
+          return column.width !== undefined
+            ? typeof column.width == 'number'
+              ? column.width + 'px'
+              : column.width
+            : `auto`;
+        }),
       },
       ...state,
     }


### PR DESCRIPTION
It works in situations where we kept the resized width of grid columns.