### PR TITLE
docs: react-virtuoso example

### DIFF
--- a/docs/src/manifests/manifest.json
+++ b/docs/src/manifests/manifest.json
@@ -226,6 +226,11 @@
               "editUrl": "/docs/examples/virtualized-rows.mdx"
             },
             {
+              "title": "Virtualized Rows (React Virtuoso)",
+              "path": "/docs/examples/virtualized-rows-virtuoso",
+              "editUrl": "/docs/examples/virtualized-rows-virtuoso.mdx"
+            },
+            {
               "title": "Animated (Framer-Motion)",
               "path": "/docs/examples/animated-framer-motion",
               "editUrl": "/docs/examples/animated-framer-motion.mdx"

--- a/docs/src/pages/docs/examples/virtualized-rows-virtuoso.md
+++ b/docs/src/pages/docs/examples/virtualized-rows-virtuoso.md
@@ -1,0 +1,22 @@
+---
+id: virtualized-rows-virtuoso
+title: Virtualized Rows (React Virtuoso)
+toc: false
+---
+
+- [Open in CodeSandbox](https://codesandbox.io/s/react-table-with-react-virtuoso-7pq7w)
+
+<iframe src="https://codesandbox.io/embed/react-table-with-react-virtuoso-7pq7w?fontsize=14&hidenavigation=1&theme=dark&module=%2FApp.js"
+title="react-table-with-react-virtuoso"
+sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+style={{
+width: '100%',
+         height: '80vh',
+         border: '0',
+         borderRadius: 8,
+         overflow: 'hidden',
+         position: 'static',
+         zIndex: 0,
+}}
+></iframe>
+


### PR DESCRIPTION
The PR adds an additional help article that showcases the integration between the two libraries. The format follows the existing react-window example. 