### PR TITLE
Types reflect that row.original is never undefined

### DIFF
--- a/packages/react-table/src/core.tsx
+++ b/packages/react-table/src/core.tsx
@@ -166,7 +166,7 @@ export type TableCore<TData, TValue, TFilterFns, TSortingFns, TAggregationFns> =
     ) => Cell<TData, TValue, TFilterFns, TSortingFns, TAggregationFns>
     createRow: (
       id: string,
-      original: TData | undefined,
+      original: TData,
       rowIndex: number,
       depth: number,
       values: Record<string, any>


### PR DESCRIPTION
As far as I can tell this is ok? Then you don't have to do null checks in calling code that wants to use `row.original`.