### PR TITLE
defaultCanSort has no effect as a column attribute

### DIFF
--- a/docs/src/pages/docs/api/useSortBy.md
+++ b/docs/src/pages/docs/api/useSortBy.md
@@ -55,7 +55,7 @@ The following options are supported via the main options object passed to `useTa
 
 The following options are supported on any `Column` object passed to the `columns` options in `useTable()`
 
-- `defaultCanSort: Bool`
+- `canSort: Bool`
   - Optional
   - Defaults to `false`
   - If set to `true`, this column will be sortable, regardless if it has a valid `accessor`


### PR DESCRIPTION
`defaultCanSort` is never accessed off of the column object. in useSortBy.js:232:    
const {
      accessor,
      canSort: defaultColumnCanSort,
      disableSortBy: columnDisableSortBy,
      id,
    } = column
We see that `canSort` is destructured into a variable named `defaultColumnCanSort`. But the column option it's looking at is `canSort`, so that is what works when specified. It would be a separate code change to make `defaultColumnCanSort` a valid attribute with this behavior, but today neither `defaultColumnCanSort` nor `defaultCanSort` work as column attributes.