### PR TITLE
Use accessor type to narrow value type in createDataColumn

### DIFF
--- a/packages/table-core/src/createTable.tsx
+++ b/packages/table-core/src/createTable.tsx
@@ -78,11 +78,17 @@ export type TableFactory<TGenerics extends Partial<DefaultGenerics>> = {
     column: Overwrite<
       TAccessor extends (...args: any[]) => any
         ? // Accessor Fn
-          _NonGenerated<ColumnDef<TGenerics>>
+          _NonGenerated<
+            ColumnDef<Overwrite<TGenerics, { Value: ReturnType<TAccessor> }>>
+          >
         : TAccessor extends keyof TGenerics['Row']
         ? // Accessor Key
           Overwrite<
-            _NonGenerated<ColumnDef<TGenerics>>,
+            _NonGenerated<
+              ColumnDef<
+                Overwrite<TGenerics, { Value: TGenerics['Row'][TAccessor] }>
+              >
+            >,
             {
               id?: string
             }
@@ -93,7 +99,18 @@ export type TableFactory<TGenerics extends Partial<DefaultGenerics>> = {
         accessorKey?: never
       }
     >
-  ) => ColumnDef<TGenerics>
+  ) => ColumnDef<
+    Overwrite<
+      TGenerics,
+      {
+        Value: TAccessor extends (...args: any[]) => any
+          ? ReturnType<TAccessor>
+          : TAccessor extends keyof TGenerics['Row']
+          ? TGenerics['Row'][TAccessor]
+          : never
+      }
+    >
+  >
 }
 
 export function createTable<TRow>() {


### PR DESCRIPTION
I think 5636cf45298d164520042e4a9a5b848419f5f376 broke inference of the value type based on the accessor. The values are stuck at the default `unknown`.

```tsx
const table = createTable<Disk>()

const columns = table.createColumns([
  table.createDataColumn('name', {
    header: 'Name',
    cell: ({ value }) => <div>{value}</div>, // <-- value has type unknown
  }),
  table.createDataColumn((d) => d.state.state, {
    id: 'status',
    header: 'Status',
    cell: ({ value }) => <DiskStatusBadge status={value} />, // also unknown
  }),
])
```

I tested this fix in my project by modifying the copy inside `node_modules` and it did bring back the inference, so it seems to be the right idea even though it's ugly. All I really did was bring back what was going on before the breaking commit:

https://github.com/TanStack/react-table/blob/f27720c53b581521aceac3ad76c5a6d4fa1f18c3/packages/react-table/src/createTable.tsx#L103-L150