### PR TITLE
add getIsSomeRowsExpanded instance property (v8 alpha)

### DIFF
--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -62,6 +62,7 @@ export type ExpandedInstance<TGenerics extends PartialGenerics> = {
   getToggleAllRowsExpandedProps: <TGetter extends Getter<ToggleExpandedProps>>(
     userProps?: TGetter
   ) => undefined | PropGetterValue<ToggleExpandedProps, TGetter>
+  getIsSomeRowsExpanded: () => boolean
   getIsAllRowsExpanded: () => boolean
   getExpandedDepth: () => number
   getExpandedRowModel: () => RowModel<TGenerics>
@@ -228,6 +229,10 @@ export const Expanding = {
         }
 
         return propGetter(initialProps, userProps)
+      },
+      getIsSomeRowsExpanded: () => {
+        const expanded = instance.getState().expanded
+        return expanded === true || Object.values(expanded).some(Boolean)
       },
       getIsAllRowsExpanded: () => {
         const expanded = instance.getState().expanded


### PR DESCRIPTION
A small and efficient addition to the expanded feature I use in my project.

In most cases where expanded state is not handled manually, this should be an instant constant lookup time.