### PR TITLE
Feat getIsSomeColumnPinned table instance method (v8)

### DIFF
--- a/packages/table-core/src/features/Expanding.ts
+++ b/packages/table-core/src/features/Expanding.ts
@@ -62,6 +62,7 @@ export type ExpandedInstance<TGenerics extends PartialGenerics> = {
   getToggleAllRowsExpandedProps: <TGetter extends Getter<ToggleExpandedProps>>(
     userProps?: TGetter
   ) => undefined | PropGetterValue<ToggleExpandedProps, TGetter>
+  getIsSomeRowsExpanded: () => boolean
   getIsAllRowsExpanded: () => boolean
   getExpandedDepth: () => number
   getExpandedRowModel: () => RowModel<TGenerics>
@@ -228,6 +229,10 @@ export const Expanding = {
         }
 
         return propGetter(initialProps, userProps)
+      },
+      getIsSomeRowsExpanded: () => {
+        const expanded = instance.getState().expanded
+        return expanded === true || Object.values(expanded).some(Boolean)
       },
       getIsAllRowsExpanded: () => {
         const expanded = instance.getState().expanded

--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -47,6 +47,7 @@ export type ColumnPinningInstance<TGenerics extends PartialGenerics> = {
   getColumnCanPin: (columnId: string) => boolean
   getColumnIsPinned: (columnId: string) => ColumnPinningPosition
   getColumnPinnedIndex: (columnId: string) => number
+  getIsSomeColumnsPinned: () => boolean
 }
 
 //
@@ -173,6 +174,12 @@ export const Pinning = {
               -1
           : 0
       },
+
+      getIsSomeColumnsPinned: () => {
+        const { left, right } = instance.getState().columnPinning
+
+        return Boolean(left?.length || right?.length)
+      }
     }
   },
 }

--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -179,7 +179,7 @@ export const Pinning = {
         const { left, right } = instance.getState().columnPinning
 
         return Boolean(left?.length || right?.length)
-      }
+      },
     }
   },
 }


### PR DESCRIPTION
Another small utility function to tell whether or not the current table state has column pinning on at all.

This can be useful if in a split table needs to add specific styles and logic based on whether or not pinning is splitting the table.

[Example here](https://github.com/KevinVandy/material-react-table/blob/0d0fc6a0800e99a52e6c27adee5a6091413bf80b/src/table/MRT_TableContainer.tsx#L80)