### PR TITLE
feat: Record columnDefType to CoreColumn (v8)

### DIFF
--- a/packages/table-core/src/core.tsx
+++ b/packages/table-core/src/core.tsx
@@ -197,11 +197,14 @@ export type CoreColumnDef<TGenerics extends AnyGenerics> = {
 }
 // & GeneratedProperties<true>
 
+export type CoreColumnDefType = 'data' | 'display' | 'group'
+
 export type CoreColumn<TGenerics extends AnyGenerics> = {
   id: string
   depth: number
   accessorFn?: AccessorFn<TGenerics['Row']>
   columnDef: ColumnDef<TGenerics>
+  columnDefType: CoreColumnDefType
   getWidth: () => number
   columns: Column<TGenerics>[]
   parent?: Column<TGenerics>
@@ -299,7 +302,11 @@ export function createTableInstance<TGenerics extends AnyGenerics>(
 
     getColumnDefs: () => instance.options.columns,
 
-    createColumn: (columnDef, depth: number, parent) => {
+    createColumn: (
+      columnDef: ColumnDef<TGenerics> & { columnDefType?: CoreColumnDefType },
+      depth: number,
+      parent
+    ) => {
       const defaultColumn = instance.getDefaultColumn()
 
       let id =
@@ -335,6 +342,7 @@ export function createTableInstance<TGenerics extends AnyGenerics>(
         parent: parent as any,
         depth,
         columnDef,
+        columnDefType: columnDef.columnDefType as CoreColumnDefType,
         columns: [],
         getWidth: () => instance.getColumnWidth(column.id),
         getFlatColumns: memo(

--- a/packages/table-core/src/createTable.tsx
+++ b/packages/table-core/src/createTable.tsx
@@ -133,11 +133,12 @@ function _createTable<TGenerics extends AnyGenerics>(
       },
     },
     createColumns: columns => columns,
-    createDisplayColumn: column => column as any,
-    createGroup: column => column as any,
+    createDisplayColumn: column => ({ ...column, columnDefType: 'display' }),
+    createGroup: column => ({ ...column, columnDefType: 'group' } as any),
     createDataColumn: (accessor, column): any => {
       column = {
         ...column,
+        columnDefType: 'data',
         id: column.id,
       }
 


### PR DESCRIPTION
In my use of react-table v8, there are dozens of instances where different render logic and css are wanted based solely on whether or not a column is a display column, data column, or whether or not a column has child columns.

I believe simply recording with of `table.createDataColumn(...)`, `table.createDisplayColumn(...)`, or `table.createDataColumn(...)` was used to create the column could be very useful in simplifying this kind of logic.