### PR TITLE
fix(getCanNextPage): Use the `getPageCount` function over manual calculation on the fly

### DIFF
--- a/packages/table-core/src/features/Pagination.ts
+++ b/packages/table-core/src/features/Pagination.ts
@@ -187,7 +187,7 @@ export const Pagination = {
       getCanPreviousPage: () => instance.getState().pagination.pageIndex > 0,
 
       getCanNextPage: () => {
-        const { pageIndex, pageSize } = instance.getState().pagination
+        const { pageIndex } = instance.getState().pagination
 
         const pageCount = instance.getPageCount()
 
@@ -199,13 +199,7 @@ export const Pagination = {
           return false
         }
 
-        return (
-          pageIndex <
-          Math.ceil(
-            instance.getPrePaginationRowModel().rows.length / pageSize
-          ) -
-            1
-        )
+        return pageIndex < pageCount - 1
       },
 
       previousPage: () => {


### PR DESCRIPTION
This update will ensure that the `getCanNextPage` function works correctly when doing server side pagination (or some other form of pagination handled outside of react-tables internals).

One thing to not is while I've manually tested this, my changes didn't trigger / get picked up by any of the tests when running `yarn dev`. I could add one but that could take up some time to figure out, is there an outline on how to quickly add a test for v8? I see some of the current tests are still from the old (v7). 