### PR TITLE
import performance module for node < v16 until platforms like Vercel support node 16

### DIFF
--- a/packages/table-core/src/utils.tsx
+++ b/packages/table-core/src/utils.tsx
@@ -1,3 +1,4 @@
+import { performance } from 'perf_hooks' //needed until node 16 is more universal
 import { Getter, NoInfer, PropGetterValue, TableState, Updater } from './types'
 
 export type IsAny<T> = 0 extends 1 & T ? true : false


### PR DESCRIPTION
Vercel builds throw an error `ReferenceError: performance is not defined` because Vercel supports a max node version of node v14 still, where the performance module is not yet globally defined.

Stack Overflow: https://stackoverflow.com/questions/46436943/referenceerror-performance-is-not-defined-when-using-performance-now