### PR TITLE
Revert "import performance module for node < v16 until platforms like Vercel support node 16"

### DIFF
--- a/packages/table-core/src/utils.tsx
+++ b/packages/table-core/src/utils.tsx
@@ -1,4 +1,3 @@
-import { performance } from 'perf_hooks' //needed until node 16 is more universal
 import { Getter, NoInfer, PropGetterValue, TableState, Updater } from './types'
 
 export type IsAny<T> = 0 extends 1 & T ? true : false


### PR DESCRIPTION
Reverts TanStack/react-table#3833