### PR TITLE
keep example lockfiles in sync when releasing

### DIFF
--- a/examples/basic/yarn.lock
+++ b/examples/basic/yarn.lock
@@ -286,6 +286,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -646,11 +658,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/column-ordering/yarn.lock
+++ b/examples/column-ordering/yarn.lock
@@ -261,6 +261,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/column-pinning/yarn.lock
+++ b/examples/column-pinning/yarn.lock
@@ -261,6 +261,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/column-sizing/yarn.lock
+++ b/examples/column-sizing/yarn.lock
@@ -261,6 +261,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -603,11 +615,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/column-visibility/yarn.lock
+++ b/examples/column-visibility/yarn.lock
@@ -236,11 +236,6 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@reach/observe-rect@^1.1.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
-  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
-
 "@rollup/plugin-replace@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.1.tgz#f774550f482091719e52e9f14f67ffc0046a883d"
@@ -265,6 +260,18 @@
   dependencies:
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
+
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
 
 "@types/estree@0.0.39":
   version "0.0.39"
@@ -608,18 +615,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
-
-react-virtual@2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.10.0.tgz#110cc0f48bb6edffd253f532123a074e6bbec4cb"
-  integrity sha512-Mgy//1Ty0YMcELTooFq5mMrEb4dLRzS9PbPrgDbpdgGRgG9RuQrXBxgPCm1vNBonoiNZjbsGSEPLuJ7MuHLvLg==
-  dependencies:
-    "@reach/observe-rect" "^1.1.0"
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/expanding/yarn.lock
+++ b/examples/expanding/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/filters/yarn.lock
+++ b/examples/filters/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/fully-controlled/yarn.lock
+++ b/examples/fully-controlled/yarn.lock
@@ -291,6 +291,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -651,11 +663,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/grouping/yarn.lock
+++ b/examples/grouping/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/pagination/yarn.lock
+++ b/examples/pagination/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/row-selection/yarn.lock
+++ b/examples/row-selection/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -608,11 +620,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/examples/sorting/yarn.lock
+++ b/examples/sorting/yarn.lock
@@ -266,6 +266,18 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
+"@tanstack/react-table@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.28.tgz#e902849607c80f76fe83b7beeb4cd5312212f59d"
+  integrity sha512-DB/fsXWjNzwqAGbM+f5/Lc4B2Isrjnfr0jB50oP4WjFlCKEFh0ph3z7ldFO3U5lg1RPWMuSjJAkCGeUWQEbiGQ==
+  dependencies:
+    "@tanstack/table-core" "8.0.0-alpha.28"
+
+"@tanstack/table-core@8.0.0-alpha.28":
+  version "8.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.28.tgz#e8ac1bd2275df44d6bbcdd9a531961595c98f07c"
+  integrity sha512-SXP1rFWKfYhrwpZkP/gnlqUvscXONKnFTT5aFtzW03+o+AxfW8Q8ulDnVsXZ7Ed8OsA93d63eYdCdv9vfc/68Q==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -613,11 +625,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react@^17.0.2:
   version "17.0.2"

--- a/packages/react-table-devtools/package.json
+++ b/packages/react-table-devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tanstack/react-table-devtools",
   "author": "Tanner Linsley",
-  "version": "8.0.0-alpha.21",
+  "version": "8.0.0-alpha.28",
   "description": "Devtools for React Table",
   "license": "MIT",
   "homepage": "https://github.com/tanstack/react-table#readme",

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -520,6 +520,19 @@ async function updateExamplesPackageConfig(
   let json = await jsonfile.readFile(file)
   transform(json)
   await jsonfile.writeFile(file, json, { spaces: 2 })
+
+  updateExampleLockFile(example)
+}
+
+function updateExampleLockFile(packageName: string) {
+  const cwd = path.join(
+    rootDir,
+    'examples',
+    getPackageDir(packageName)
+  )
+
+  // execute yarn to update lockfile, ignoring any stdout or stderr
+  execSync('yarn', { cwd, stdio: 'ignore' })
 }
 
 function packageJson(packageName: string, directory = 'packages') {


### PR DESCRIPTION
As part of digging into the examples and thinking about how to upgrade a complex project from v7 to v8 I identified some opportunities for cleanup:

 - tidy up lockfiles and keep them in sync with the latest release
 - clean up unused code in some examples

This PR addresses the first one, and I've added it to the `scripts/publish.ts` script and tested locally:

```
$ TAG=v8.0.0-alpha.28 ./node_modules/.bin/ts-node scripts/publish.ts
Tag is set to v8.0.0-alpha.28. This will force release all packages. Publishing...
Parsing 1397 commits since v8.0.0-alpha.28...
Generating changelog...

Version 8.0.0-alpha.28 - 2022-04-17, 2:20 p.m.

## Changes

Manual Release: v8.0.0-alpha.28

## Packages

- @tanstack/table-core@8.0.0-alpha.28
- @tanstack/react-table@8.0.0-alpha.28
- @tanstack/react-table-devtools@8.0.0-alpha.28

Building packages...

/home/shiftkey/src/react-table/packages/table-core/src/index.tsx → packages/table-core/build/esm...
created packages/table-core/build/esm in 1.9s

/home/shiftkey/src/react-table/packages/table-core/src/index.tsx → packages/table-core/build/cjs...
created packages/table-core/build/cjs in 987ms

/home/shiftkey/src/react-table/packages/table-core/src/index.tsx → packages/table-core/build/umd/index.development.js...
created packages/table-core/build/umd/index.development.js in 1s

/home/shiftkey/src/react-table/packages/table-core/src/index.tsx → packages/table-core/build/umd/index.production.js...
created packages/table-core/build/umd/index.production.js in 1.9s

/home/shiftkey/src/react-table/packages/react-table/src/index.tsx → packages/react-table/build/esm...
created packages/react-table/build/esm in 129ms

/home/shiftkey/src/react-table/packages/react-table/src/index.tsx → packages/react-table/build/cjs...
created packages/react-table/build/cjs in 97ms

/home/shiftkey/src/react-table/packages/react-table/src/index.tsx → packages/react-table/build/umd/index.development.js...
created packages/react-table/build/umd/index.development.js in 90ms

/home/shiftkey/src/react-table/packages/react-table/src/index.tsx → packages/react-table/build/umd/index.production.js...
created packages/react-table/build/umd/index.production.js in 506ms

/home/shiftkey/src/react-table/packages/react-table-devtools/src/index.tsx → packages/react-table-devtools/build/esm...
created packages/react-table-devtools/build/esm in 309ms

/home/shiftkey/src/react-table/packages/react-table-devtools/src/index.tsx → packages/react-table-devtools/build/cjs...
created packages/react-table-devtools/build/cjs in 227ms

/home/shiftkey/src/react-table/packages/react-table-devtools/src/index.tsx → packages/react-table-devtools/build/umd/index.development.js...
created packages/react-table-devtools/build/umd/index.development.js in 223ms

/home/shiftkey/src/react-table/packages/react-table-devtools/src/index.tsx → packages/react-table-devtools/build/umd/index.production.js...
created packages/react-table-devtools/build/umd/index.production.js in 881ms
Linking packages...
lerna notice cli v4.0.0
lerna info Executing command in 3 packages: "yarn link"
lerna success exec Executed command in 3 packages: "yarn link"
lerna notice cli v4.0.0
lerna info Executing command in 3 packages: "yarn link @tanstack/react-table"
lerna success exec Executed command in 3 packages: "yarn link @tanstack/react-table"
Testing packages...
PASS react-table packages/react-table/__tests__/features/Visibility.test.tsx
PASS table-core packages/table-core/__tests__/features/Visibility.test.tsx
PASS table-core packages/table-core/__tests__/core/core.test.tsx
PASS react-table packages/react-table/__tests__/core/core.test.tsx

Test Suites: 4 passed, 4 total
Tests:       8 passed, 8 total
Snapshots:   14 passed, 14 total
Time:        3.181 s
Ran all test suites in 2 projects.

Updating all changed packages and their dependencies to version 8.0.0-alpha.28...
  Updating @tanstack/table-core version to 8.0.0-alpha.28...
  Updating @tanstack/react-table version to 8.0.0-alpha.28...
    Updating dependency on @tanstack/react-table to version 8.0.0-alpha.28.
  Updating @tanstack/react-table-devtools version to 8.0.0-alpha.28...
Updating examples dependencies...
  Updating example basic to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example column-ordering to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example column-pinning to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example column-sizing to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example column-visibility to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example expanding to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example filters to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example fully-controlled to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example grouping to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example pagination to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example row-selection to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
  Updating example sorting to version 8.0.0-alpha.28...
    Updating dependency @tanstack/react-table to version 8.0.0-alpha.28...
This is a dry run for version 8.0.0-alpha.28. Push to CI to publish for real or set CI=true to override!
```

The remaining commits on this PR are for the updated lockfiles under `examples/`, and then a package that doesn't seem to be up-to-date with the others in the workspace.

Happy to adapt this to whatever format suits, as I appreciate that this may not be your highest priority at the moment...