### PR TITLE
add getIsSomeVisibleColumnsPinned instance method

### DIFF
--- a/packages/table-core/src/features/Pinning.ts
+++ b/packages/table-core/src/features/Pinning.ts
@@ -48,6 +48,7 @@ export type ColumnPinningInstance<TGenerics extends AnyGenerics> = {
   getColumnIsPinned: (columnId: string) => ColumnPinningPosition
   getColumnPinnedIndex: (columnId: string) => number
   getIsSomeColumnsPinned: () => boolean
+  getIsSomeVisibleColumnsPinned: () => boolean
 }
 
 //
@@ -179,6 +180,10 @@ export const Pinning = {
         const { left, right } = instance.getState().columnPinning
 
         return Boolean(left?.length || right?.length)
+      },
+
+      getIsSomeVisibleColumnsPinned: () => {
+        return instance.getVisibleLeafColumns().some(d => d.getIsPinned())
       },
     }
   },


### PR DESCRIPTION
Discovered accounting for column visibility was useful for the above getIsSomeColumnsPinned. 
Don't know if this should be added in addition to previous method, or replace it.