### PR TITLE
fix type declarations for adapters

### DIFF
--- a/packages/vue-table/tsconfig.json
+++ b/packages/vue-table/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "outDir": "./build/types"
   },
-  "files": ["src/index.tsx"],
+  "files": ["src/index.ts"],
   "include": [
     "src"
     //  "__tests__/**/*.test.*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,9 @@
     "paths": {
       "@tanstack/table-core": ["packages/table-core"],
       "@tanstack/react-table": ["packages/react-table"],
-      "@tanstack/react-table-devtools": ["packages/react-table-devtools"]
+      "@tanstack/react-table-devtools": ["packages/react-table-devtools"],
+      "@tanstack/solid-table": ["packages/solid-table"],
+      "@tanstack/vue-table": ["packages/vue-table"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
   "references": [
     { "path": "packages/table-core" },
     { "path": "packages/react-table" },
+    { "path": "packages/solid-table" },
+    { "path": "packages/vue-table" },
     { "path": "packages/react-table-devtools" }
   ]
   // "exclude": ["node_modules"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,11 +2143,6 @@
   resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.0.0-alpha.1.tgz#47ab73a3872b3fc10468259993f1a3121aa327c8"
   integrity sha512-0fwp0ihCrvAhA3KWXdWMA3RL9uw3M/UjUvEVkj9APaBt1Q0fJmBTQfzAg3590MraLjRpiiX9/YsRLKj8Dv5b1w==
 
-"@tanstack/table-core@8.0.0-alpha.30":
-  version "8.0.0-alpha.30"
-  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.0.0-alpha.30.tgz#cec207bc869af82cfcbe314ed840a2756a17e900"
-  integrity sha512-oz15xICZ7zwQvt/KUUCrvpKt569c5/f83p19CDKvFCcyXC1Yls/WfdSgodqYAuHEgQER0HCn8UDXZyMIcnrTkg==
-
 "@testing-library/dom@^8.0.0":
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"


### PR DESCRIPTION
The `vue-table` and `solid-table` packages weren't outputting type declarations because they weren't referenced in the root `tsconfig.json`. This PR fixes that.