### PR TITLE
Take out `extends object` on row, table meta, and column meta

### DIFF
--- a/packages/table-core/src/createTable.ts
+++ b/packages/table-core/src/createTable.ts
@@ -24,13 +24,11 @@ export type CreateTableOptions<
 export type Table<TGenerics extends AnyGenerics> = {
   generics: TGenerics
   options: Partial<Options<TGenerics>>
-  setRowType: <TRow extends object>() => Table<
-    Overwrite<TGenerics, { Row: TRow }>
-  >
-  setTableMetaType: <TTableMeta extends object>() => Table<
+  setRowType: <TRow>() => Table<Overwrite<TGenerics, { Row: TRow }>>
+  setTableMetaType: <TTableMeta>() => Table<
     Overwrite<TGenerics, { TableMeta: TTableMeta }>
   >
-  setColumnMetaType: <TColumnMeta extends object>() => Table<
+  setColumnMetaType: <TColumnMeta>() => Table<
     Overwrite<TGenerics, { ColumnMeta: TColumnMeta }>
   >
   setOptions: <


### PR DESCRIPTION
I can't figure out how to run a global typechecker so I can't confirm the types pass. But hopefully CI will do that.