### PR TITLE
fix ssr warning due to `useLayoutEffect`

### DIFF
--- a/packages/react-table/src/index.tsx
+++ b/packages/react-table/src/index.tsx
@@ -52,6 +52,9 @@ function isExoticComponent(component: any) {
 
 export const createTable = createTableFactory({ render })
 
+const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+
 export function useTableInstance<TGenerics extends AnyGenerics>(
   table: Table<TGenerics>,
   options: PartialKeys<
@@ -93,7 +96,7 @@ export function useTableInstance<TGenerics extends AnyGenerics>(
     },
   }))
 
-  React.useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     instance.willUpdate()
   })
 


### PR DESCRIPTION
The react adapter was calling `useLayoutEffect` which showed a warning during SSR. This PR makes the `useLayoutEffect` isomorphic and switches it for `useEffect` on server