### PR TITLE
Fix environment check in react adapter

### DIFF
--- a/packages/react-table/src/index.tsx
+++ b/packages/react-table/src/index.tsx
@@ -53,7 +53,7 @@ function isExoticComponent(component: any) {
 export const createTable = createTableFactory({ render })
 
 const useIsomorphicLayoutEffect =
-  typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect
+  typeof document !== 'undefined' ? React.useLayoutEffect : React.useEffect
 
 export function useTableInstance<TGenerics extends TableGenerics>(
   table: Table<TGenerics>,


### PR DESCRIPTION
This PR changes the `typeof window` check to see whether the code is running on the server to `typeof document` as a few server runtimes like deno have `window` as a global