### PR TITLE
fix: update the babel targets to not transpile classes

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,23 +1,24 @@
-const { NODE_ENV, BABEL_ENV } = process.env;
-const cjs = NODE_ENV === "test" || BABEL_ENV === "commonjs";
-const loose = true;
+const { NODE_ENV, BABEL_ENV } = process.env
+const cjs = NODE_ENV === 'test' || BABEL_ENV === 'commonjs'
+const loose = true
 
 module.exports = {
+  targets: 'defaults, not ie 11, not ie_mob 11',
   presets: [
     [
-      "@babel/env",
+      '@babel/env',
       {
         loose,
         modules: false,
         // exclude: ['@babel/plugin-transform-regenerator'],
       },
     ],
-    "@babel/react",
-    "@babel/preset-typescript",
+    '@babel/react',
+    '@babel/preset-typescript',
   ],
   plugins: [
     // 'babel-plugin-transform-async-to-promises',
-    cjs && ["@babel/transform-modules-commonjs", { loose }],
+    cjs && ['@babel/transform-modules-commonjs', { loose }],
     // [
     //   '@babel/transform-runtime',
     //   {
@@ -28,4 +29,4 @@ module.exports = {
     //   },
     // ],
   ].filter(Boolean),
-};
+}


### PR DESCRIPTION
This PR updates the babel targets so as to not transpile the classes in svelte adapter to functions, which caused runtime issues. The target it now sets is `defaults, not ie 11, not ie_mob 11`, which might be too high, but I think that most users of react-table are probably already transpiling their code to lower targets if they want browser compat, so it shouldn't be an issue