### PR TITLE
fixed Uncaught TypeError: Cannot read properties of undefined (reading 'pluginName')

### DIFF
--- a/src/publicUtils.js
+++ b/src/publicUtils.js
@@ -106,7 +106,7 @@ export function ensurePluginOrder(plugins, befores, pluginName, afters) {
     )
   }
   const pluginIndex = plugins.findIndex(
-    plugin => plugin.pluginName === pluginName
+    plugin => plugin && plugin.pluginName === pluginName
   )
 
   if (pluginIndex === -1) {
@@ -121,7 +121,7 @@ This usually means you need to need to name your plugin hook by setting the 'plu
 
   befores.forEach(before => {
     const beforeIndex = plugins.findIndex(
-      plugin => plugin.pluginName === before
+      plugin => plugin && plugin.pluginName === before
     )
     if (beforeIndex > -1 && beforeIndex > pluginIndex) {
       if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
When no plugin founded there is no exception

```
Test Suites: 41 passed, 41 total
Tests:       51 passed, 51 total
Snapshots:   0 total
Time:        26.12s
Ran all test suites in 2 projects.
```

Build success

Fix bug #3909 