### PR TITLE
fix vue render type

### DIFF
--- a/packages/vue-table/src/index.ts
+++ b/packages/vue-table/src/index.ts
@@ -12,7 +12,7 @@ import { mergeProxy } from './merge-proxy'
 
 export * from '@tanstack/table-core'
 
-function render<TProps extends {}>(Comp: any, props: TProps): VNode | null {
+function render<TProps extends {}>(Comp: any, props: TProps): VNode | string | number | boolean | null {
   if (!Comp) return null
 
   if (typeof Comp === 'function') {


### PR DESCRIPTION
The PR fixes the type of `render` function in vue adapter. The previous type didn't allow the cells/columns to be a string and required for it to be a vnode. This allows it to be a number, string or boolean and aligns it with the react adapter