### PR TITLE
add a check for filtering the data columns with type boolean

### DIFF
--- a/packages/table-core/src/features/Filters.ts
+++ b/packages/table-core/src/features/Filters.ts
@@ -217,6 +217,10 @@ export const Filters: TableFeature = {
           return filterFns.inNumberRange
         }
 
+        if (typeof value === 'boolean') {
+          return filterFns.equals
+        }
+
         if (value !== null && typeof value === 'object') {
           return filterFns.equals
         }


### PR DESCRIPTION
I realize that there is no check for filtering the boolean values in the filter feature.

In my opinion below code snippet in `getAutoFilterFn` in `/Filters.ts` may satisfy the issue.

```typescript
if (typeof value === 'boolean') {
    return filterFns.equals
}
```